### PR TITLE
Fix #4: nested, indirect descendant, <button> causes infinite loop.

### DIFF
--- a/html5lib/html5parser.py
+++ b/html5lib/html5parser.py
@@ -926,8 +926,8 @@ def getPhases(debug):
             self.endTagHandler = utils.MethodDispatcher([
                 ("body", self.endTagBody),
                 ("html", self.endTagHtml),
-                (("address", "article", "aside", "blockquote", "center",
-                  "details", "dir", "div", "dl", "fieldset", "figcaption", "figure",
+                (("address", "article", "aside", "blockquote", "button", "center",
+                  "details", "dialog", "dir", "div", "dl", "fieldset", "figcaption", "figure",
                   "footer", "header", "hgroup", "listing", "menu", "nav", "ol", "pre",
                   "section", "summary", "ul"), self.endTagBlock),
                 ("form", self.endTagForm),


### PR DESCRIPTION
A couple of elements (button, dialog) were missing from the list of
endTagBlock in-body-phase dispatcher. This adds them.

See https://github.com/html5lib/html5lib-tests/pull/4 for test.
