### PR TITLE
Google Code Issue 215: Properly detect seekable streams

### DIFF
--- a/html5lib/inputstream.py
+++ b/html5lib/inputstream.py
@@ -201,11 +201,6 @@ class HTMLUnicodeInputStream:
         else:
             stream = StringIO(source)
 
-        try:
-            stream.seek(stream.tell())
-        except:
-            stream = BufferedStream(stream)
-
         return stream
 
     def _position(self, offset):


### PR DESCRIPTION
> This patch removes the hack that tests for sys.stdin to determine if the stream is seekable (it has tell() and seek() but it is not seekable), by actually calling tell() and seek().

/@jcarlosgarciasegovia
