### PR TITLE
Fix #6: html5lib.treebuilders.dom.dom2sax crashes on 'xml:lang' attribute

### DIFF
--- a/html5lib/tests/support.py
+++ b/html5lib/tests/support.py
@@ -4,6 +4,7 @@ import os
 import sys
 import codecs
 import glob
+import xml.sax.handler
 
 base_path = os.path.split(__file__)[0]
 
@@ -131,3 +132,45 @@ def errorMessage(input, expected, actual):
     if sys.version_info.major == 2:
         msg = msg.encode("ascii", "backslashreplace")
     return msg
+
+
+class TracingSaxHandler(xml.sax.handler.ContentHandler):
+    def __init__(self):
+        xml.sax.handler.ContentHandler.__init__(self)
+        self.visited = []
+
+    def startDocument(self):
+        self.visited.append('startDocument')
+
+    def endDocument(self):
+        self.visited.append('endDocument')
+
+    def startPrefixMapping(self, prefix, uri):
+        self.visited.append(('prefix', prefix, uri))
+
+    def endPrefixMapping(self, prefix):
+        self.visited.append(('endPrefixMapping', prefix))
+
+    def startElement(self, name, attrs):
+        self.visited.append(('startElement', name, attrs))
+
+    def endElement(self, name):
+        self.visited.append(('endElement', name))
+
+    def startElementNS(self, name, qname, attrs):
+        self.visited.append(('startElementNS', name, qname, attrs))
+
+    def endElementNS(self, name, qname):
+        self.visited.append(('endElementNS', name, qname))
+
+    def characters(self, content):
+        self.visited.append(('characters', content))
+
+    def ignorableWhitespace(self, whitespace):
+        self.visited.append(('ignorableWhitespace', whitespace))
+
+    def processingInstruction(self, target, data):
+        self.visited.append(('processingInstruction', target, data))
+
+    def skippedEntity(self, name):
+        self.visited.append(('skippedEntity', name))

--- a/html5lib/tests/test_parser2.py
+++ b/html5lib/tests/test_parser2.py
@@ -36,7 +36,7 @@ class MoreParserTests(unittest.TestCase):
 
     def test_unicode_file(self):
         parser = html5parser.HTMLParser()
-        doc = parser.parse(io.StringIO("a"))
+        parser.parse(io.StringIO("a"))
 
 
 def buildTestSuite():

--- a/html5lib/tests/test_treeadapters.py
+++ b/html5lib/tests/test_treeadapters.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, unicode_literals
+
+from . import support  # flake8: noqa
+from html5lib import html5parser
+from html5lib.treebuilders import dom
+
+
+def test_dom2sax():
+    handler = support.TracingSaxHandler()
+    parser = html5parser.HTMLParser(tree=dom.TreeBuilder)
+    dom_object = parser.parse("""<html xml:lang="en">
+        <title>Directory Listing</title>
+        <a href="/"><b/></p>
+    """)
+    dom.dom2sax(dom_object, handler)
+    expected = [
+        'startDocument',
+        ('startElementNS', ('http://www.w3.org/1999/xhtml', 'html'),
+            'html', {('http://www.w3.org/XML/1998/namespace', 'lang'): 'en'}),
+        ('startElementNS', ('http://www.w3.org/1999/xhtml', 'head'), 'head', {}),
+        ('startElementNS', ('http://www.w3.org/1999/xhtml', 'title'), 'title', {}),
+        ('characters', 'Directory Listing'),
+        ('endElementNS', ('http://www.w3.org/1999/xhtml', 'title'), 'title'),
+        ('characters', '\n        '),
+        ('endElementNS', ('http://www.w3.org/1999/xhtml', 'head'), 'head'),
+        ('startElementNS',  ('http://www.w3.org/1999/xhtml', 'body'), 'body', {}),
+        ('startElementNS', ('http://www.w3.org/1999/xhtml', 'a'), 'a', {(None,'href'): '/'}),
+        ('startElementNS', ('http://www.w3.org/1999/xhtml', 'b'), 'b', {}),
+        ('startElementNS', ('http://www.w3.org/1999/xhtml', 'p'), 'p', {}),
+        ('endElementNS', ('http://www.w3.org/1999/xhtml', 'p'), 'p'),
+        ('characters', '\n    '),
+        ('endElementNS', ('http://www.w3.org/1999/xhtml', 'b'), 'b'),
+        ('endElementNS', ('http://www.w3.org/1999/xhtml', 'a'), 'a'),
+        ('endElementNS', ('http://www.w3.org/1999/xhtml', 'body'), 'body'),
+        ('endElementNS', ('http://www.w3.org/1999/xhtml', 'html'), 'html'),
+        'endDocument',
+    ]
+    assert expected == handler.visited

--- a/html5lib/treebuilders/dom.py
+++ b/html5lib/treebuilders/dom.py
@@ -246,10 +246,15 @@ def getDomBuilder(DomImplementation):
                 for attrname in list(node.attributes.keys()):
                     attr = node.getAttributeNode(attrname)
                     if attr.namespaceURI is None and ':' in attr.nodeName:
-                        prefix = attr.nodeName.split(':')[0]
+                        prefix, localName = attr.nodeName.split(':', 1)
                         if prefix in nsmap:
-                            del attributes[(attr.namespaceURI, attr.nodeName)]
-                            attributes[(nsmap[prefix], attr.nodeName)] = attr.nodeValue
+                            try:
+                                del attributes[(attr.namespaceURI, attr.nodeName)]
+                            except KeyError:
+                                del attributes[(attr.namespaceURI, localName)]
+                            else:
+                                localName = attr.nodeName
+                            attributes[(nsmap[prefix], localName)] = attr.nodeValue
 
                 # SAX events
                 ns = node.namespaceURI or nsmap.get(None, None)


### PR DESCRIPTION
I couldn't fix any dom2sax tests so I added a new one in `test_parser2`.
