### PR TITLE
Removed `print()` from library code and 3to2 leftovers

### DIFF
--- a/html5lib/ihatexml.py
+++ b/html5lib/ihatexml.py
@@ -171,8 +171,6 @@ def escapeRegexp(string):
                          "[", "]", "|", "(", ")", "-")
     for char in specialCharacters:
         string = string.replace(char, "\\" + char)
-        if char in string:
-            print(string)
 
     return string
 

--- a/html5lib/serializer/htmlserializer.py
+++ b/html5lib/serializer/htmlserializer.py
@@ -6,7 +6,6 @@ _ = gettext.gettext
 
 try:
     from functools import reduce
-    pass  # no-op statement to avoid 3to2 introducing parse error
 except ImportError:
     pass
 
@@ -35,11 +34,7 @@ else:
             if len(v) == 2:
                 v = utils.surrogatePairToCodepoint(v)
             else:
-                try:
-                    v = ord(v)
-                except:
-                    print(v)
-                    raise
+                v = ord(v)
             if not v in encode_entity_map or k.islower():
                 # prefer &lt; over &LT; and similarly for &amp;, &gt;, etc.
                 encode_entity_map[v] = k

--- a/html5lib/treebuilders/etree_lxml.py
+++ b/html5lib/treebuilders/etree_lxml.py
@@ -323,12 +323,7 @@ class TreeBuilder(_base.TreeBuilder):
             if self.doctype.name != token["name"]:
                 warnings.warn("lxml cannot represent doctype with a different name to the root element", DataLossWarning)
         docStr += "<THIS_SHOULD_NEVER_APPEAR_PUBLICLY/>"
-
-        try:
-            root = etree.fromstring(docStr)
-        except etree.XMLSyntaxError:
-            print(docStr)
-            raise
+        root = etree.fromstring(docStr)
 
         # Append the initial comments:
         for comment_token in self.initial_comments:


### PR DESCRIPTION
In both cases the try-except block was only necessary for printing, thus removed as well.
