### PR TITLE
Use the default ElementTree implementation in getTreeWalker as well

### DIFF
--- a/html5lib/treebuilders/__init__.py
+++ b/html5lib/treebuilders/__init__.py
@@ -28,6 +28,8 @@ to the format used in the unittests
 
 from __future__ import absolute_import, division, unicode_literals
 
+from html5lib.utils import getDefaultEtreeImpl
+
 treeBuilderCache = {}
 
 
@@ -66,11 +68,7 @@ def getTreeBuilder(treeType, implementation=None, **kwargs):
         elif treeType == "etree":
             # Come up with a sane default (pref. from the stdlib)
             if implementation is None:
-                try:
-                    import xml.etree.cElementTree as ET
-                except ImportError:
-                    import xml.etree.ElementTree as ET
-                implementation = ET
+                implementation = getDefaultEtreeImpl()
             from . import etree
             # NEVER cache here, caching is done in the etree submodule
             return etree.getETreeModule(implementation, **kwargs).TreeBuilder

--- a/html5lib/treewalkers/__init__.py
+++ b/html5lib/treewalkers/__init__.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import, division, unicode_literals
 
 import sys
 
+from html5lib.utils import getDefaultEtreeImpl
+
 treeWalkerCache = {}
 
 
@@ -47,6 +49,8 @@ def getTreeWalker(treeType, implementation=None, **kwargs):
             from . import lxmletree
             treeWalkerCache[treeType] = lxmletree.TreeWalker
         elif treeType == "etree":
+            if implementation is None:
+                implementation = getDefaultEtreeImpl()
             from . import etree
             # XXX: NEVER cache here, caching is done in the etree submodule
             return etree.getETreeModule(implementation, **kwargs).TreeWalker

--- a/html5lib/utils.py
+++ b/html5lib/utils.py
@@ -71,3 +71,11 @@ def moduleFactoryFactory(factory):
             return mod
 
     return moduleFactory
+
+
+def getDefaultEtreeImpl():
+    try:
+        import xml.etree.cElementTree as ET
+    except ImportError:
+        import xml.etree.ElementTree as ET
+    return ET


### PR DESCRIPTION
The following fails without the patch:

```
>>> html5lib.getTreeWalker("etree")
Traceback (most recent call last):
...
AttributeError: 'NoneType' object has no attribute '__name__'
```
