### PR TITLE
Use OrderedDict for arguments in etree walker

### DIFF
--- a/html5lib/treewalkers/etree.py
+++ b/html5lib/treewalkers/etree.py
@@ -1,5 +1,12 @@
 from __future__ import absolute_import, division, unicode_literals
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        OrderedDict = dict
 import gettext
 _ = gettext.gettext
 
@@ -61,7 +68,7 @@ def getETreeBuilder(ElementTreeImplementation):
                 else:
                     namespace = None
                     tag = node.tag
-                attrs = {}
+                attrs = OrderedDict()
                 for name, value in list(node.attrib.items()):
                     match = tag_regexp.match(name)
                     if match:


### PR DESCRIPTION
This ensures the order of attributes is predictable. Useful for instance in django_compressor's test suite.
