### PR TITLE
Fix #83: Stop testing the DOM treewalker with pxdom

### DIFF
--- a/html5lib/tests/test_treewalkers.py
+++ b/html5lib/tests/test_treewalkers.py
@@ -83,16 +83,6 @@ else:
          "walker": treewalkers.getTreeWalker("lxml")}
 
 
-# Try whatever etree implementations are available from a list that are
-#"supposed" to work
-try:
-    import pxdom
-    treeTypes['pxdom'] = \
-        {"builder": treebuilders.getTreeBuilder("dom", pxdom),
-         "walker": treewalkers.getTreeWalker("dom")}
-except ImportError:
-    pass
-
 try:
     from genshi.core import QName, Attrs
     from genshi.core import START, END, TEXT, COMMENT, DOCTYPE


### PR DESCRIPTION
This hasn't actually been tested in years and almost certainly won't
work; furthermore pxdom isn't supported under Python 3 so it doesn't
provide any testing whatsoever for a strict DOM implementation there.
