### PR TITLE
Fixes 115 FragmentWrapper.isstring handles unicode

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Patches and suggestions
 - Juan Carlos Garcia Segovia
 - Mike West
 - Marc DM
+- Alexandre Leray

--- a/html5lib/treewalkers/lxmletree.py
+++ b/html5lib/treewalkers/lxmletree.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, unicode_literals
-from six import text_type
+from six import text_type, string_types, binary_type
 
 from lxml import etree
 from ..treebuilders.etree import tag_regexp
@@ -87,7 +87,7 @@ class FragmentWrapper(object):
             self.tail = ensure_str(self.obj.tail)
         else:
             self.tail = None
-        self.isstring = isinstance(obj, str) or isinstance(obj, bytes)
+        self.isstring = isinstance(obj, string_types) or isinstance(obj, binary_type)
         # Support for bytes here is Py2
         if self.isstring:
             self.obj = ensure_str(self.obj)


### PR DESCRIPTION
More info on https://github.com/html5lib/html5lib-python/issues/115
