### PR TITLE
Add a usedEncoding method to HTML5Parser, fix #121

### DIFF
--- a/html5lib/html5parser.py
+++ b/html5lib/html5parser.py
@@ -129,15 +129,16 @@ class HTMLParser(object):
 
         self.framesetOK = True
 
-    def usedEncoding(self):
-        """Return the name of the character encoding
+    @property
+    def documentEncoding(self):
+        """The name of the character encoding
         that was used to decode the input stream,
         or :obj:`None` if that is not determined yet.
 
         """
         if not hasattr(self, 'tokenizer'):
             return None
-        return self.tokenizer.stream.usedEncoding()
+        return self.tokenizer.stream.documentEncoding
 
     def isHTMLIntegrationPoint(self, element):
         if (element.name == "annotation-xml" and

--- a/html5lib/inputstream.py
+++ b/html5lib/inputstream.py
@@ -142,6 +142,8 @@ class HTMLUnicodeInputStream(object):
 
     _defaultChunkSize = 10240
 
+    documentEncoding = None  # No encoding involved for Unicode input.
+
     def __init__(self, source):
         """Initialises the HTMLInputStream.
 
@@ -174,9 +176,6 @@ class HTMLUnicodeInputStream(object):
         self.dataStream = self.openStream(source)
 
         self.reset()
-
-    def usedEncoding(self):
-        return None  # No encoding involved for Unicode input.
 
     def reset(self):
         self.chunk = ""
@@ -416,7 +415,8 @@ class HTMLBinaryInputStream(HTMLUnicodeInputStream):
         # Call superclass
         self.reset()
 
-    def usedEncoding(self):
+    @property
+    def documentEncoding(self):
         return self.charEncoding[0]
 
     def reset(self):

--- a/html5lib/tests/test_encoding.py
+++ b/html5lib/tests/test_encoding.py
@@ -28,33 +28,33 @@ class Html5EncodingTestCase(unittest.TestCase):
 
 def test_unicode_input_encoding():
     p = HTMLParser()
-    assert p.usedEncoding() is None
+    assert p.documentEncoding is None
     p.parse(b'<meta charset=latin2>', useChardet=False)
-    assert p.usedEncoding() == 'iso8859-2'
+    assert p.documentEncoding == 'iso8859-2'
 
     p = HTMLParser()
-    assert p.usedEncoding() is None
+    assert p.documentEncoding is None
     p.parse('<meta charset=latin2>')
-    assert p.usedEncoding() is None
+    assert p.documentEncoding is None
 
     p = HTMLParser()
-    assert p.usedEncoding() is None
+    assert p.documentEncoding is None
     try:
         p.parse('<meta charset=latin2>', encoding='latin3')
     except TypeError:
         pass
     else:
         assert 0, 'Expected TypeError'
-    assert p.usedEncoding() is None
+    assert p.documentEncoding is None
 
 
 def runParserEncodingTest(data, encoding):
     p = HTMLParser()
-    assert p.usedEncoding() is None
+    assert p.documentEncoding is None
     p.parse(data, useChardet=False)
     encoding = encoding.lower().decode("ascii")
 
-    assert encoding == p.usedEncoding(), errorMessage(data, encoding, p.usedEncoding())
+    assert encoding == p.documentEncoding, errorMessage(data, encoding, p.documentEncoding)
 
 
 def runPreScanEncodingTest(data, encoding):


### PR DESCRIPTION
This turned out to be easy enough to add.

I don’t really like the `usedEncoding` name, but I don’t have a better idea. Feel free to suggest something else.
