### PR TITLE
Make changes for pip 1.5

### DIFF
--- a/requirements-install.sh
+++ b/requirements-install.sh
@@ -9,8 +9,8 @@ pip install -r requirements-test.txt
 
 if [[ $USE_OPTIONAL == "true" && $TRAVIS_PYTHON_VERSION != "pypy" ]]; then
   if [[ $TRAVIS_PYTHON_VERSION == "2.6" ]]; then
-    pip install --allow-external Genshi --allow-unverified Genshi -r requirements-optional-2.6.txt
+    pip install --allow-external Genshi --allow-insecure Genshi -r requirements-optional-2.6.txt
   else
-    pip install --allow-external Genshi --allow-unverified Genshi -r requirements-optional-cpython.txt
+    pip install --allow-external Genshi --allow-insecure Genshi -r requirements-optional-cpython.txt
   fi
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
   {envbindir}/nosetests -q
   {toxinidir}/flake8-run.sh
 install_command =
-  pip install --allow-external Genshi --allow-unverified Genshi {opts} {packages}
+  pip install --allow-external Genshi --allow-insecure Genshi {opts} {packages}
 
 [testenv:pypy]
 # lxml doesn't work and datrie doesn't make sense


### PR DESCRIPTION
This drops the insecure `--use-mirrors`, and allows Genshi to be installed insecurely. Once Travis CI upgrades, everything would fail as a result.
