### PR TITLE
Fixing SVG close tag bug

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Patches and suggestions
 - Juan Carlos Garcia Segovia
 - Mike West
 - Marc DM
+- Sam Cooke

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Change Log
 
 Released on XXX, 2014
 
+* Fix: SVG end tags were not being adjusted
+
 * XXX
 
 

--- a/html5lib/html5parser.py
+++ b/html5lib/html5parser.py
@@ -2445,6 +2445,8 @@ def getPhases(debug):
         def processEndTag(self, token):
             nodeIndex = len(self.tree.openElements) - 1
             node = self.tree.openElements[-1]
+            if node.namespace == namespaces["svg"]:
+                self.adjustSVGTagNames(token)
             if node.name != token["name"]:
                 self.parser.parseError("unexpected-end-tag", {"name": token["name"]})
 

--- a/html5lib/tests/test_parser2.py
+++ b/html5lib/tests/test_parser2.py
@@ -51,6 +51,10 @@ class MoreParserTests(unittest.TestCase):
         parser = html5parser.HTMLParser()
         parser.parse(io.StringIO("a"))
 
+    def test_svg_token(self):
+        parser = html5parser.HTMLParser(strict=True)
+        parser.parseFragment("<svg><switch><foreignObject></foreignObject></switch></svg>")
+
 
 def buildTestSuite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
The test fails on current master - I'm new to this library so I may have fixed it in the wrong way or missed other places where it would fail but this solves my problem.