### PR TITLE
Replace invalid characters with U+FFFD (fixes #96)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Patches and suggestions
 - Juan Carlos Garcia Segovia
 - Mike West
 - Marc DM
+- Leif Arne Storset

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Change Log
 Released on XXX, 2014
 
 * XXX
+* Fix #96: replace invalid characters from "Preprocessing the input stream" with
+  U+FFFD, preventing problems in lxml.
 
 
 0.999

--- a/html5lib/inputstream.py
+++ b/html5lib/inputstream.py
@@ -270,6 +270,7 @@ class HTMLUnicodeInputStream(object):
         # Replace invalid characters
         # Note U+0000 is dealt with in the tokenizer
         data = self.replaceCharactersRegexp.sub("\ufffd", data)
+        data = invalid_unicode_re.sub("\ufffd", data)
 
         data = data.replace("\r\n", "\n")
         data = data.replace("\r", "\n")


### PR DESCRIPTION
This fix simply repeats the encoding-specific replacement with a general one using invalid_unicode_re. It corresponds to section 12.2.2.5. I can't quite tell what the spec says to do if one of these characters is encountered, but the rest of the spec replaces other characters with U+FFFD, so I did that (despite Simon's preference of the empty string).

I can submit a test for this (AFAICT I have to do that separately).
