### PR TITLE
Add expected failures

### DIFF
--- a/html5lib/tests/expected-failures/tokenizer.dat
+++ b/html5lib/tests/expected-failures/tokenizer.dat
@@ -37,7 +37,4 @@
 <!DOCTYPE
 
 #data
-I'm &no
-
-#data
 <!DOCTYPE 	

--- a/html5lib/tests/expected-failures/tokenizer.dat
+++ b/html5lib/tests/expected-failures/tokenizer.dat
@@ -1,0 +1,43 @@
+#data
+<!DOCTYPE>
+
+#data
+<!DOCTYPE >
+
+#data
+<!DOCTYPE	
+
+#data
+<!DOCTYPE
+
+
+#data
+<!DOCTYPE
+
+#data
+<!DOCTYPE
+
+#data
+<!DOCTYPE 
+
+
+#data
+<!DOCTYPE 
+
+#data
+<!DOCTYPE 
+
+#data
+<!DOCTYPE  
+
+#data
+<!DOCTYPE 
+
+#data
+<!DOCTYPE
+
+#data
+I'm &no
+
+#data
+<!DOCTYPE 	

--- a/html5lib/tests/expected-failures/tree-construction.dat
+++ b/html5lib/tests/expected-failures/tree-construction.dat
@@ -1,0 +1,59 @@
+#data
+<html><ruby>a<rtc>b<rt>c<rb>d</ruby></html>
+
+#data
+<html><ruby>a<rb>b<rt></ruby></html>
+
+#data
+<!DOCTYPE html><body><svg attributename='' attributetype='' basefrequency='' baseprofile='' calcmode='' clippathunits='' contentscripttype='' contentstyletype='' diffuseconstant='' edgemode='' externalresourcesrequired='' filterres='' filterunits='' glyphref='' gradienttransform='' gradientunits='' kernelmatrix='' kernelunitlength='' keypoints='' keysplines='' keytimes='' lengthadjust='' limitingconeangle='' markerheight='' markerunits='' markerwidth='' maskcontentunits='' maskunits='' numoctaves='' pathlength='' patterncontentunits='' patterntransform='' patternunits='' pointsatx='' pointsaty='' pointsatz='' preservealpha='' preserveaspectratio='' primitiveunits='' refx='' refy='' repeatcount='' repeatdur='' requiredextensions='' requiredfeatures='' specularconstant='' specularexponent='' spreadmethod='' startoffset='' stddeviation='' stitchtiles='' surfacescale='' systemlanguage='' tablevalues='' targetx='' targety='' textlength='' viewbox='' viewtarget='' xchannelselector='' ychannelselector='' zoomandpan=''></svg>
+
+#data
+<html><ruby>a<rt>b<rb></ruby></html>
+
+#data
+<html><ruby>a<rt>b<rtc></ruby></html>
+
+#data
+<html><ruby><rtc><ruby>a<rb>b<rt></ruby></ruby></html>
+
+#data
+<!DOCTYPE html><body><command>A
+
+#data
+<html><ruby>a<rb>b<rp></ruby></html>
+
+#data
+<!DOCTYPE html><body><svg attributeName='' attributeType='' baseFrequency='' baseProfile='' calcMode='' clipPathUnits='' contentScriptType='' contentStyleType='' diffuseConstant='' edgeMode='' externalResourcesRequired='' filterRes='' filterUnits='' glyphRef='' gradientTransform='' gradientUnits='' kernelMatrix='' kernelUnitLength='' keyPoints='' keySplines='' keyTimes='' lengthAdjust='' limitingConeAngle='' markerHeight='' markerUnits='' markerWidth='' maskContentUnits='' maskUnits='' numOctaves='' pathLength='' patternContentUnits='' patternTransform='' patternUnits='' pointsAtX='' pointsAtY='' pointsAtZ='' preserveAlpha='' preserveAspectRatio='' primitiveUnits='' refX='' refY='' repeatCount='' repeatDur='' requiredExtensions='' requiredFeatures='' specularConstant='' specularExponent='' spreadMethod='' startOffset='' stdDeviation='' stitchTiles='' surfaceScale='' systemLanguage='' tableValues='' targetX='' targetY='' textLength='' viewBox='' viewTarget='' xChannelSelector='' yChannelSelector='' zoomAndPan=''></svg>
+
+#data
+<html><ruby>a<rtc>b<rtc></ruby></html>
+
+#data
+<!DOCTYPE html><frameset> te st
+
+#data
+<html><ruby>a<rp>b<rtc></ruby></html>
+
+#data
+<!DOCTYPE html><frameset></frameset> te st
+
+#data
+<html><ruby>a<rb>b<rb></ruby></html>
+
+#data
+<html><ruby>a<rtc>b<rp></ruby></html>
+
+#data
+<!DOCTYPE html><body><menuitem>A
+
+#data
+<!DOCTYPE html><BODY><SVG ATTRIBUTENAME='' ATTRIBUTETYPE='' BASEFREQUENCY='' BASEPROFILE='' CALCMODE='' CLIPPATHUNITS='' CONTENTSCRIPTTYPE='' CONTENTSTYLETYPE='' DIFFUSECONSTANT='' EDGEMODE='' EXTERNALRESOURCESREQUIRED='' FILTERRES='' FILTERUNITS='' GLYPHREF='' GRADIENTTRANSFORM='' GRADIENTUNITS='' KERNELMATRIX='' KERNELUNITLENGTH='' KEYPOINTS='' KEYSPLINES='' KEYTIMES='' LENGTHADJUST='' LIMITINGCONEANGLE='' MARKERHEIGHT='' MARKERUNITS='' MARKERWIDTH='' MASKCONTENTUNITS='' MASKUNITS='' NUMOCTAVES='' PATHLENGTH='' PATTERNCONTENTUNITS='' PATTERNTRANSFORM='' PATTERNUNITS='' POINTSATX='' POINTSATY='' POINTSATZ='' PRESERVEALPHA='' PRESERVEASPECTRATIO='' PRIMITIVEUNITS='' REFX='' REFY='' REPEATCOUNT='' REPEATDUR='' REQUIREDEXTENSIONS='' REQUIREDFEATURES='' SPECULARCONSTANT='' SPECULAREXPONENT='' SPREADMETHOD='' STARTOFFSET='' STDDEVIATION='' STITCHTILES='' SURFACESCALE='' SYSTEMLANGUAGE='' TABLEVALUES='' TARGETX='' TARGETY='' TEXTLENGTH='' VIEWBOX='' VIEWTARGET='' XCHANNELSELECTOR='' YCHANNELSELECTOR='' ZOOMANDPAN=''></SVG>
+
+#data
+<html><ruby>a<rp>b<rb></ruby></html>
+
+#data
+<html><ruby>a<rb>b<rtc></ruby></html>
+
+#data
+<html><ruby>a<rtc>b<rb></ruby></html>

--- a/html5lib/tests/support.py
+++ b/html5lib/tests/support.py
@@ -6,6 +6,8 @@ import codecs
 import glob
 import xml.sax.handler
 
+from nose.plugins.skip import SkipTest
+
 base_path = os.path.split(__file__)[0]
 
 test_dir = os.path.join(base_path, 'testdata')
@@ -182,6 +184,8 @@ def xfail(test):
     def t(*args, **kwargs):
         try:
             test(*args)
+        except SkipTest:
+            raise
         except:
             return
         else:

--- a/html5lib/tests/support.py
+++ b/html5lib/tests/support.py
@@ -130,7 +130,7 @@ convertExpected = convert(2)
 def errorMessage(input, expected, actual):
     msg = ("Input:\n%s\nExpected:\n%s\nRecieved\n%s\n" %
            (repr(input), repr(expected), repr(actual)))
-    if sys.version_info.major == 2:
+    if sys.version_info[0] == 2:
         msg = msg.encode("ascii", "backslashreplace")
     return msg
 

--- a/html5lib/tests/support.py
+++ b/html5lib/tests/support.py
@@ -175,3 +175,15 @@ class TracingSaxHandler(xml.sax.handler.ContentHandler):
 
     def skippedEntity(self, name):
         self.visited.append(('skippedEntity', name))
+
+
+def xfail(test):
+    """Expected fail decorator function"""
+    def t(*args, **kwargs):
+        try:
+            test(*args)
+        except:
+            return
+        else:
+            assert False, "UNEXPECTED PASS"
+    return t

--- a/html5lib/tests/test_encoding.py
+++ b/html5lib/tests/test_encoding.py
@@ -8,6 +8,8 @@ try:
 except AttributeError:
     unittest.TestCase.assertEqual = unittest.TestCase.assertEquals
 
+from nose.plugins.skip import SkipTest
+
 from .support import get_data_files, TestData, test_dir, errorMessage
 from html5lib import HTMLParser, inputstream
 
@@ -41,7 +43,7 @@ def runPreScanEncodingTest(data, encoding):
 
     # Very crude way to ignore irrelevant tests
     if len(data) > stream.numBytesMeta:
-        return
+        raise SkipTest()
 
     assert encoding == stream.charEncoding[0], errorMessage(data, encoding, stream.charEncoding[0])
 

--- a/html5lib/tests/test_parser.py
+++ b/html5lib/tests/test_parser.py
@@ -8,6 +8,8 @@ import re
 
 warnings.simplefilter("error")
 
+from nose.plugins.skip import SkipTest
+
 from .support import get_data_files
 from .support import TestData, convert, convertExpected, treeTypes
 from .support import xfail
@@ -30,7 +32,7 @@ def runParserTest(innerHTML, input, expected, errors, treeClass,
                   namespaceHTMLElements, scriptingDisabled):
     if scriptingDisabled:
         # We don't support the scripting disabled case!
-        return
+        raise SkipTest()
 
     with warnings.catch_warnings(record=True) as caughtWarnings:
         warnings.simplefilter("always")
@@ -51,7 +53,7 @@ def runParserTest(innerHTML, input, expected, errors, treeClass,
                      if not issubclass(x.category, constants.DataLossWarning)]
     assert len(otherWarnings) == 0, [(x.category, x.message) for x in otherWarnings]
     if len(caughtWarnings):
-        return
+        raise SkipTest()
 
     output = convertTreeDump(p.tree.testSerializer(document))
 

--- a/html5lib/tests/test_parser.py
+++ b/html5lib/tests/test_parser.py
@@ -10,6 +10,7 @@ warnings.simplefilter("error")
 
 from .support import get_data_files
 from .support import TestData, convert, convertExpected, treeTypes
+from .support import xfail
 from html5lib import html5parser, constants
 
 # Run the parse error checks
@@ -26,7 +27,11 @@ namespaceExpected = re.compile(r"^(\s*)<(\S+)>", re.M).sub
 
 
 def runParserTest(innerHTML, input, expected, errors, treeClass,
-                  namespaceHTMLElements):
+                  namespaceHTMLElements, scriptingDisabled):
+    if scriptingDisabled:
+        # We don't support the scripting disabled case!
+        return
+
     with warnings.catch_warnings(record=True) as caughtWarnings:
         warnings.simplefilter("always")
         p = html5parser.HTMLParser(tree=treeClass,
@@ -71,10 +76,24 @@ def runParserTest(innerHTML, input, expected, errors, treeClass,
         assert len(p.errors) == len(errors), errorMsg2
 
 
-def test_parser():
-    sys.stderr.write('Testing tree builders ' + " ".join(list(treeTypes.keys())) + "\n")
-    files = get_data_files('tree-construction')
+@xfail
+def xfailRunParserTest(*args, **kwargs):
+    return runParserTest(*args, **kwargs)
 
+
+def test_parser():
+    # Testin'
+    sys.stderr.write('Testing tree builders ' + " ".join(list(treeTypes.keys())) + "\n")
+
+    # Get xfails
+    filename = os.path.join(os.path.split(__file__)[0],
+                            "expected-failures",
+                            "tree-construction.dat")
+    xfails = TestData(filename, "data")
+    xfails = frozenset([x["data"] for x in xfails])
+
+    # Get the tests
+    files = get_data_files('tree-construction')
     for filename in files:
         testName = os.path.basename(filename).replace(".dat", "")
         if testName in ("template",):
@@ -84,13 +103,25 @@ def test_parser():
 
         for index, test in enumerate(tests):
             input, errors, innerHTML, expected = [test[key] for key in
-                                                  ('data', 'errors',
+                                                  ('data',
+                                                   'errors',
                                                    'document-fragment',
                                                    'document')]
+
             if errors:
                 errors = errors.split("\n")
 
+            assert not ("script-off" in test and "script-on" in test), \
+                ("The following test has scripting enabled" +
+                 "and disabled all at once: %s in %s" % (input, filename))
+
+            scriptingDisabled = "script-off" in test
+
             for treeName, treeCls in treeTypes.items():
                 for namespaceHTMLElements in (True, False):
-                    yield (runParserTest, innerHTML, input, expected, errors, treeCls,
-                           namespaceHTMLElements)
+                    if input in xfails:
+                        testFunc = xfailRunParserTest
+                    else:
+                        testFunc = runParserTest
+                    yield (testFunc, innerHTML, input, expected, errors, treeCls,
+                           namespaceHTMLElements, scriptingDisabled)

--- a/html5lib/tests/test_parser.py
+++ b/html5lib/tests/test_parser.py
@@ -68,7 +68,7 @@ def runParserTest(innerHTML, input, expected, errors, treeClass,
                            "\nExpected errors (" + str(len(errors)) + "):\n" + "\n".join(errors),
                            "\nActual errors (" + str(len(p.errors)) + "):\n" + "\n".join(errStr)])
     if checkParseErrors:
-            assert len(p.errors) == len(errors), errorMsg2
+        assert len(p.errors) == len(errors), errorMsg2
 
 
 def test_parser():

--- a/html5lib/tests/test_tokenizer.py
+++ b/html5lib/tests/test_tokenizer.py
@@ -108,6 +108,7 @@ def tokensMatch(expectedTokens, receivedTokens, ignoreErrorOrder,
                 token.pop()
 
     if not ignoreErrorOrder and not ignoreErrors:
+        expectedTokens = concatenateCharacterTokens(expectedTokens)
         return expectedTokens == receivedTokens
     else:
         # Sort the tokens into two groups; non-parse errors and parse errors
@@ -120,6 +121,7 @@ def tokensMatch(expectedTokens, receivedTokens, ignoreErrorOrder,
                 else:
                     if not ignoreErrors:
                         tokens[tokenType][1].append(token)
+            tokens[tokenType][0] = concatenateCharacterTokens(tokens[tokenType][0])
         return tokens["expected"] == tokens["received"]
 
 
@@ -144,7 +146,7 @@ def runTokenizerTest(test):
     warnings.resetwarnings()
     warnings.simplefilter("error")
 
-    expected = concatenateCharacterTokens(test['output'])
+    expected = test['output']
     if 'lastStartTag' not in test:
         test['lastStartTag'] = None
     parser = TokenizerTestParser(test['initialState'],

--- a/html5lib/tests/test_tokenizer.py
+++ b/html5lib/tests/test_tokenizer.py
@@ -152,7 +152,6 @@ def runTokenizerTest(test):
     parser = TokenizerTestParser(test['initialState'],
                                  test['lastStartTag'])
     tokens = parser.parse(test['input'])
-    tokens = concatenateCharacterTokens(tokens)
     received = normalizeTokens(tokens)
     errorMsg = "\n".join(["\n\nInitial state:",
                           test['initialState'],

--- a/html5lib/tests/test_treewalkers.py
+++ b/html5lib/tests/test_treewalkers.py
@@ -11,7 +11,7 @@ try:
 except AttributeError:
     unittest.TestCase.assertEqual = unittest.TestCase.assertEquals
 
-from .support import get_data_files, TestData, convertExpected
+from .support import get_data_files, TestData, convertExpected, xfail
 
 from html5lib import html5parser, treewalkers, treebuilders, constants
 
@@ -250,7 +250,11 @@ class TokenTestCase(unittest.TestCase):
                 self.assertEqual(expectedToken, outputToken)
 
 
-def runTreewalkerTest(innerHTML, input, expected, errors, treeClass):
+def runTreewalkerTest(innerHTML, input, expected, errors, treeClass, scriptingDisabled):
+    if scriptingDisabled:
+        # We don't support the scripting disabled case!
+        return
+
     warnings.resetwarnings()
     warnings.simplefilter("error")
     try:
@@ -281,9 +285,22 @@ def runTreewalkerTest(innerHTML, input, expected, errors, treeClass):
         pass  # Amnesty for those that confess...
 
 
+@xfail
+def xfailRunTreewalkerTest(*args, **kwargs):
+    return runTreewalkerTest(*args, **kwargs)
+
+
 def test_treewalker():
     sys.stdout.write('Testing tree walkers ' + " ".join(list(treeTypes.keys())) + "\n")
 
+    # Get xfails
+    filename = os.path.join(os.path.split(__file__)[0],
+                            "expected-failures",
+                            "tree-construction.dat")
+    xfails = TestData(filename, "data")
+    xfails = frozenset([x["data"] for x in xfails])
+
+    # Get the tests
     for treeName, treeCls in treeTypes.items():
         files = get_data_files('tree-construction')
         for filename in files:
@@ -299,7 +316,18 @@ def test_treewalker():
                                                                "document-fragment",
                                                                "document")]
                 errors = errors.split("\n")
-                yield runTreewalkerTest, innerHTML, input, expected, errors, treeCls
+
+                assert not ("script-off" in test and "script-on" in test), \
+                    ("The following test has scripting enabled" +
+                     "and disabled all at once: %s in %s" % (input, filename))
+
+                scriptingDisabled = "script-off" in test
+
+                if input in xfails:
+                    testFunc = xfailRunTreewalkerTest
+                else:
+                    testFunc = runTreewalkerTest
+                yield testFunc, innerHTML, input, expected, errors, treeCls, scriptingDisabled
 
 
 def set_attribute_on_first_child(docfrag, name, value, treeName):

--- a/html5lib/tests/test_treewalkers.py
+++ b/html5lib/tests/test_treewalkers.py
@@ -11,6 +11,8 @@ try:
 except AttributeError:
     unittest.TestCase.assertEqual = unittest.TestCase.assertEquals
 
+from nose.plugins.skip import SkipTest
+
 from .support import get_data_files, TestData, convertExpected, xfail
 
 from html5lib import html5parser, treewalkers, treebuilders, constants
@@ -253,7 +255,7 @@ class TokenTestCase(unittest.TestCase):
 def runTreewalkerTest(innerHTML, input, expected, errors, treeClass, scriptingDisabled):
     if scriptingDisabled:
         # We don't support the scripting disabled case!
-        return
+        raise SkipTest()
 
     warnings.resetwarnings()
     warnings.simplefilter("error")
@@ -265,7 +267,7 @@ def runTreewalkerTest(innerHTML, input, expected, errors, treeClass, scriptingDi
             document = p.parse(input)
     except constants.DataLossWarning:
         # Ignore testcases we know we don't pass
-        return
+        raise SkipTest()
 
     document = treeClass.get("adapter", lambda x: x)(document)
     try:
@@ -282,7 +284,7 @@ def runTreewalkerTest(innerHTML, input, expected, errors, treeClass, scriptingDi
                 "", "Diff:", diff,
         ])
     except NotImplementedError:
-        pass  # Amnesty for those that confess...
+        raise SkipTest() # Amnesty for those that confess...
 
 
 @xfail

--- a/html5lib/treebuilders/etree_lxml.py
+++ b/html5lib/treebuilders/etree_lxml.py
@@ -79,7 +79,7 @@ def testSerializer(element):
                     next_element = next_element.getnext()
             elif isinstance(element, str) or isinstance(element, bytes):
                 # Text in a fragment
-                assert isinstance(element, str) or sys.version_info.major == 2
+                assert isinstance(element, str) or sys.version_info[0] == 2
                 rv.append("|%s\"%s\"" % (' ' * indent, element))
             else:
                 # Fragment case


### PR DESCRIPTION
This isn't quite finished: notably, we still have four failures in the tokeniser tests because we can't currently add the lone-surrogates tests because the expected failures file is UTF-8 and we can't have lone-surrogates there. Options are to have a WTF-8 codec or add some escapes to test data files (optionally just for new files, maybe?) or to just fix the tokeniser and worry about this later, I think. Suggestions?