### PR TITLE
setup.py: Require ordereddict for Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 import os
 import codecs
 
@@ -23,6 +26,12 @@ packages = ['html5lib'] + ['html5lib.'+name
                            if os.path.isdir(os.path.join('html5lib', name)) and
                            not name.startswith('.') and name != 'tests']
 
+install_requires = ['six']
+try:
+    from collections import OrderedDict
+except ImportError:
+    install_requires.append('ordereddict')
+
 current_dir = os.path.dirname(__file__)
 with codecs.open(os.path.join(current_dir, 'README.rst'), 'r', 'utf8') as readme_file:
     with codecs.open(os.path.join(current_dir, 'CHANGES.rst'), 'r', 'utf8') as changes_file:
@@ -38,7 +47,5 @@ setup(name='html5lib',
       maintainer='James Graham',
       maintainer_email='james@hoppipolla.co.uk',
       packages=packages,
-      install_requires=[
-          'six',
-      ],
+      install_requires=install_requires,
       )


### PR DESCRIPTION
Without this, a client who uses the alphabetical attribute sorting feature of `HTMLSerializer` on Python 2.6 will get:

``` python
  File "/Users/marca/dev/git-repos/bleach/.tox/py26/lib/python2.6/site-packages/html5lib/serializer/htmlserializer.py", line 309, in render
    return "".join(list(self.serialize(treewalker)))
  File "/Users/marca/dev/git-repos/bleach/.tox/py26/lib/python2.6/site-packages/html5lib/serializer/htmlserializer.py", line 196, in serialize
    from ..filters.alphabeticalattributes import Filter
  File "/Users/marca/dev/git-repos/bleach/.tox/py26/lib/python2.6/site-packages/html5lib/filters/alphabeticalattributes.py", line 8, in <module>
    from ordereddict import OrderedDict
ImportError: No module named ordereddict
```
