### PR TITLE
Move Dependency Into setup.py and Make Universal Wheel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Change Log
 
 Released on XXX
 
-* XXX
+* Added ordereddict as a mandatory dependency on Python 2.6.
+* Added ``lxml``, ``genshi``, ``datrie``, ``charade``, and ``all`` extras that
+  will do the right thing based on the specific interpreter implementation.
 
 
 0.9999999/1.0b8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,23 @@ setup(name='html5lib',
           'six',
       ],
       extras_require={
+          # A empty extra that only has a conditional marker will be
+          # unconditonally installed when the condition matches.
           ":python_version == '2.6'": ["ordereddict"],
+
+          # A conditional extra will only install these items when the extra is
+          # requested and the condition matches.
           "lxml:python_implementation == 'CPython'": ["lxml"],
+
+          # Standard extras, will be installed when the extra is requested.
           "genshi": ["genshi"],
           "datrie": ["datrie"],
           "charade": ["charade"],
+
+          # The all extra combines a standard extra which will be used anytime
+          # the all extra is requested, and it extends it with a conditional
+          # extra that will be installed whenever the condition matches and the
+          # all extra is requested.
           "all": ["genshi", "datrie", "charade"],
           "all:python_implementation == 'CPython'": ["lxml"],
       },

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
-from distutils.core import setup
 import ast
 import os
 import codecs
+
+from setuptools import setup
+
 
 classifiers=[
     'Development Status :: 5 - Production/Stable',
@@ -55,4 +57,13 @@ setup(name='html5lib',
       install_requires=[
           'six',
       ],
+      extras_require={
+          ":python_version == '2.6'": ["ordereddict"],
+          "lxml:python_implementation == 'CPython'": ["lxml"],
+          "genshi": ["genshi"],
+          "datrie": ["datrie"],
+          "charade": ["charade"],
+          "all": ["genshi", "datrie", "charade"],
+          "all:python_implementation == 'CPython'": ["lxml"],
+      },
       )


### PR DESCRIPTION
* Switches the setup.py to use setuptools.
* Automatically installs ``ordereddict`` on Python < 2.7.
* Adds extras which can be used to install optional dependencies like ``pip install html5lib[genshi,datrie]``. The ``lxml`` extra is conditional on CPython.
* Adds an ``all`` extra which will install all optional dependencies which correctly handles lxml on non CPython interpreters.
* Marks wheels as universal.

Fixes #165 
Fixes #179