### PR TITLE
Make lxml tree-builder coerce comments to work with lxml 3.5

### DIFF
--- a/html5lib/ihatexml.py
+++ b/html5lib/ihatexml.py
@@ -226,7 +226,7 @@ class InfosetFilter(object):
                 warnings.warn("Comments cannot contain adjacent dashes", DataLossWarning)
                 data = data.replace("--", "- -")
             if data.endswith("-"):
-                warnings.warn("Comments cannot contain end in a dash", DataLossWarning)
+                warnings.warn("Comments cannot end in a dash", DataLossWarning)
                 data += " "
         return data
 

--- a/html5lib/ihatexml.py
+++ b/html5lib/ihatexml.py
@@ -225,6 +225,8 @@ class InfosetFilter(object):
             while "--" in data:
                 warnings.warn("Comments cannot contain adjacent dashes", DataLossWarning)
                 data = data.replace("--", "- -")
+            if data.endswith("-"):
+                data += " "
         return data
 
     def coerceCharacters(self, data):

--- a/html5lib/ihatexml.py
+++ b/html5lib/ihatexml.py
@@ -226,6 +226,7 @@ class InfosetFilter(object):
                 warnings.warn("Comments cannot contain adjacent dashes", DataLossWarning)
                 data = data.replace("--", "- -")
             if data.endswith("-"):
+                warnings.warn("Comments cannot contain end in a dash", DataLossWarning)
                 data += " "
         return data
 

--- a/html5lib/treebuilders/etree_lxml.py
+++ b/html5lib/treebuilders/etree_lxml.py
@@ -54,7 +54,7 @@ class Document(object):
 def testSerializer(element):
     rv = []
     finalText = None
-    infosetFilter = ihatexml.InfosetFilter()
+    infosetFilter = ihatexml.InfosetFilter(preventDoubleDashComments=True)
 
     def serializeElement(element, indent=0):
         if not hasattr(element, "tag"):
@@ -257,7 +257,7 @@ class TreeBuilder(_base.TreeBuilder):
             data = property(_getData, _setData)
 
         self.elementClass = Element
-        self.commentClass = builder.Comment
+        self.commentClass = Comment
         # self.fragmentClass = builder.DocumentFragment
         _base.TreeBuilder.__init__(self, namespaceHTMLElements)
 
@@ -344,7 +344,8 @@ class TreeBuilder(_base.TreeBuilder):
 
         # Append the initial comments:
         for comment_token in self.initial_comments:
-            root.addprevious(etree.Comment(comment_token["data"]))
+            comment = self.commentClass(comment_token["data"])
+            root.addprevious(comment._element)
 
         # Create the root document and add the ElementTree to it
         self.document = self.documentClass()

--- a/html5lib/treebuilders/etree_lxml.py
+++ b/html5lib/treebuilders/etree_lxml.py
@@ -189,7 +189,7 @@ class TreeBuilder(_base.TreeBuilder):
 
     def __init__(self, namespaceHTMLElements, fullTree=False):
         builder = etree_builders.getETreeModule(etree, fullTree=fullTree)
-        infosetFilter = self.infosetFilter = ihatexml.InfosetFilter()
+        infosetFilter = self.infosetFilter = ihatexml.InfosetFilter(preventDoubleDashComments=True)
         self.namespaceHTMLElements = namespaceHTMLElements
 
         class Attributes(dict):


### PR DESCRIPTION
This enables the double-dash comment filter, and changes the filter to avoid trailing dashes which are equally illegal.