### PR TITLE
Lint fixes

### DIFF
--- a/html5lib/filters/lint.py
+++ b/html5lib/filters/lint.py
@@ -62,7 +62,14 @@ class Filter(_base.Filter):
             elif type == "Doctype":
                 name = token["name"]
                 assert name is None or isinstance(name, text_type)
-                # XXX: what to do with token["data"] ?
+                assert token["publicId"] is None or isinstance(name, text_type)
+                assert token["systemId"] is None or isinstance(name, text_type)
+
+            elif type == "Entity":
+                assert isinstance(token["name"], text_type)
+
+            elif type == "SerializerError":
+                assert isinstance(token["data"], text_type)
 
             else:
                 assert False, "Unknown token type: %(type)s" % {"type": type}

--- a/html5lib/filters/lint.py
+++ b/html5lib/filters/lint.py
@@ -49,7 +49,8 @@ class Filter(_base.Filter):
                     assert start == (namespace, name)
 
             elif type == "Comment":
-                pass
+                data = token["data"]
+                assert isinstance(data, text_type)
 
             elif type in ("Characters", "SpaceCharacters"):
                 data = token["data"]

--- a/html5lib/filters/lint.py
+++ b/html5lib/filters/lint.py
@@ -80,8 +80,8 @@ class Filter(_base.Filter):
 
             elif type == "Doctype":
                 name = token["name"]
-                if not isinstance(name, text_type):
-                    raise LintError("Tag name is not a string: %(tag)r" % {"tag": name})
+                if name is not None and not isinstance(name, text_type):
+                    raise LintError("Tag name is not a string or None: %(tag)r" % {"tag": name})
                 # XXX: what to do with token["data"] ?
 
             elif type in ("ParseError", "SerializeError"):

--- a/html5lib/filters/lint.py
+++ b/html5lib/filters/lint.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
+from six import text_type
+
 from . import _base
 from ..constants import cdataElements, rcdataElements, voidElements
 
@@ -21,7 +23,7 @@ class Filter(_base.Filter):
                 name = token["name"]
                 if contentModelFlag != "PCDATA":
                     raise LintError("StartTag not in PCDATA content model flag: %(tag)s" % {"tag": name})
-                if not isinstance(name, str):
+                if not isinstance(name, text_type):
                     raise LintError("Tag name is not a string: %(tag)r" % {"tag": name})
                 if not name:
                     raise LintError("Empty tag name")
@@ -32,11 +34,11 @@ class Filter(_base.Filter):
                 if type == "StartTag":
                     open_elements.append(name)
                 for name, value in token["data"]:
-                    if not isinstance(name, str):
+                    if not isinstance(name, text_type):
                         raise LintError("Attribute name is not a string: %(name)r" % {"name": name})
                     if not name:
                         raise LintError("Empty attribute name")
-                    if not isinstance(value, str):
+                    if not isinstance(value, text_type):
                         raise LintError("Attribute value is not a string: %(value)r" % {"value": value})
                 if name in cdataElements:
                     contentModelFlag = "CDATA"
@@ -47,7 +49,7 @@ class Filter(_base.Filter):
 
             elif type == "EndTag":
                 name = token["name"]
-                if not isinstance(name, str):
+                if not isinstance(name, text_type):
                     raise LintError("Tag name is not a string: %(tag)r" % {"tag": name})
                 if not name:
                     raise LintError("Empty tag name")
@@ -64,7 +66,7 @@ class Filter(_base.Filter):
 
             elif type in ("Characters", "SpaceCharacters"):
                 data = token["data"]
-                if not isinstance(data, str):
+                if not isinstance(data, text_type):
                     raise LintError("Attribute name is not a string: %(name)r" % {"name": data})
                 if not data:
                     raise LintError("%(type)s token with empty data" % {"type": type})
@@ -77,7 +79,7 @@ class Filter(_base.Filter):
                 name = token["name"]
                 if contentModelFlag != "PCDATA":
                     raise LintError("Doctype not in PCDATA content model flag: %(name)s" % {"name": name})
-                if not isinstance(name, str):
+                if not isinstance(name, text_type):
                     raise LintError("Tag name is not a string: %(tag)r" % {"tag": name})
                 # XXX: what to do with token["data"] ?
 

--- a/html5lib/filters/lint.py
+++ b/html5lib/filters/lint.py
@@ -9,10 +9,6 @@ from ..constants import spaceCharacters
 spaceCharacters = "".join(spaceCharacters)
 
 
-class LintError(Exception):
-    pass
-
-
 class Filter(_base.Filter):
     def __iter__(self):
         open_elements = []
@@ -21,73 +17,56 @@ class Filter(_base.Filter):
             if type in ("StartTag", "EmptyTag"):
                 namespace = token["namespace"]
                 name = token["name"]
-                if namespace is not None and not isinstance(namespace, text_type):
-                    raise LintError("Tag namespace is not a string or None: %(name)r" % {"name": namespace})
-                if namespace == "":
-                    raise LintError("Empty tag namespace")
-                if not isinstance(name, text_type):
-                    raise LintError("Tag name is not a string: %(tag)r" % {"tag": name})
-                if not name:
-                    raise LintError("Empty tag name")
-                if type == "StartTag" and (not namespace or namespace == namespaces["html"]) and name in voidElements:
-                    raise LintError("Void element reported as StartTag token: %(tag)s" % {"tag": name})
-                elif type == "EmptyTag" and (not namespace or namespace == namespaces["html"]) and name not in voidElements:
-                    raise LintError("Non-void element reported as EmptyTag token: %(tag)s" % {"tag": token["name"]})
+                assert namespace is None or isinstance(namespace, text_type)
+                assert namespace != ""
+                assert isinstance(name, text_type)
+                assert name != ""
+                assert isinstance(token["data"], dict)
+                if (not namespace or namespace == namespaces["html"]) and name in voidElements:
+                    assert type == "EmptyTag"
+                else:
+                    assert type == "StartTag"
                 if type == "StartTag":
                     open_elements.append((namespace, name))
-                for (namespace, localname), value in token["data"].items():
-                    if namespace is not None and not isinstance(namespace, text_type):
-                        raise LintError("Attribute namespace is not a string or None: %(name)r" % {"name": namespace})
-                    if namespace == "":
-                        raise LintError("Empty attribute namespace")
-                    if not isinstance(localname, text_type):
-                        raise LintError("Attribute localname is not a string: %(name)r" % {"name": localname})
-                    if not localname:
-                        raise LintError("Empty attribute localname")
-                    if not isinstance(value, text_type):
-                        raise LintError("Attribute value is not a string: %(value)r" % {"value": value})
+                for (namespace, name), value in token["data"].items():
+                    assert namespace is None or isinstance(namespace, text_type)
+                    assert namespace != ""
+                    assert isinstance(name, text_type)
+                    assert name != ""
+                    assert isinstance(value, text_type)
 
             elif type == "EndTag":
                 namespace = token["namespace"]
                 name = token["name"]
-                if namespace is not None and not isinstance(namespace, text_type):
-                    raise LintError("Tag namespace is not a string or None: %(name)r" % {"name": namespace})
-                if namespace == "":
-                    raise LintError("Empty tag namespace")
-                if not isinstance(name, text_type):
-                    raise LintError("Tag name is not a string: %(tag)r" % {"tag": name})
-                if not name:
-                    raise LintError("Empty tag name")
+                assert namespace is None or isinstance(namespace, text_type)
+                assert namespace != ""
+                assert isinstance(name, text_type)
+                assert name != ""
                 if (not namespace or namespace == namespaces["html"]) and name in voidElements:
-                    raise LintError("Void element reported as EndTag token: %(tag)s" % {"tag": name})
-                start_name = open_elements.pop()
-                if start_name != (namespace, name):
-                    raise LintError("EndTag (%(end)s) does not match StartTag (%(start)s)" % {"end": name, "start": start_name})
+                    assert False, "Void element reported as EndTag token: %(tag)s" % {"tag": name}
+                else:
+                    start = open_elements.pop()
+                    assert start == (namespace, name)
 
             elif type == "Comment":
                 pass
 
             elif type in ("Characters", "SpaceCharacters"):
                 data = token["data"]
-                if not isinstance(data, text_type):
-                    raise LintError("Attribute name is not a string: %(name)r" % {"name": data})
-                if not data:
-                    raise LintError("%(type)s token with empty data" % {"type": type})
+                assert isinstance(data, text_type)
+                assert data != ""
                 if type == "SpaceCharacters":
-                    data = data.strip(spaceCharacters)
-                    if data:
-                        raise LintError("Non-space character(s) found in SpaceCharacters token: %(token)r" % {"token": data})
+                    assert data.strip(spaceCharacters) == ""
 
             elif type == "Doctype":
                 name = token["name"]
-                if name is not None and not isinstance(name, text_type):
-                    raise LintError("Tag name is not a string or None: %(tag)r" % {"tag": name})
+                assert name is None or isinstance(name, text_type)
                 # XXX: what to do with token["data"] ?
 
             elif type in ("ParseError", "SerializeError"):
                 pass
 
             else:
-                raise LintError("Unknown token type: %(type)s" % {"type": type})
+                assert False, "Unknown token type: %(type)s" % {"type": type}
 
             yield token

--- a/html5lib/filters/lint.py
+++ b/html5lib/filters/lint.py
@@ -33,11 +33,15 @@ class Filter(_base.Filter):
                     raise LintError("Non-void element reported as EmptyTag token: %(tag)s" % {"tag": token["name"]})
                 if type == "StartTag":
                     open_elements.append(name)
-                for name, value in token["data"]:
-                    if not isinstance(name, text_type):
-                        raise LintError("Attribute name is not a string: %(name)r" % {"name": name})
-                    if not name:
-                        raise LintError("Empty attribute name")
+                for (namespace, localname), value in token["data"].items():
+                    if namespace is not None and not isinstance(namespace, text_type):
+                        raise LintError("Attribute namespace is not a string or None: %(name)r" % {"name": namespace})
+                    if namespace == "":
+                        raise LintError("Empty attribute namespace")
+                    if not isinstance(localname, text_type):
+                        raise LintError("Attribute localname is not a string: %(name)r" % {"name": localname})
+                    if not localname:
+                        raise LintError("Empty attribute localname")
                     if not isinstance(value, text_type):
                         raise LintError("Attribute value is not a string: %(value)r" % {"value": value})
                 if name in cdataElements:

--- a/html5lib/filters/lint.py
+++ b/html5lib/filters/lint.py
@@ -64,9 +64,6 @@ class Filter(_base.Filter):
                 assert name is None or isinstance(name, text_type)
                 # XXX: what to do with token["data"] ?
 
-            elif type in ("ParseError", "SerializeError"):
-                pass
-
             else:
                 assert False, "Unknown token type: %(type)s" % {"type": type}
 

--- a/html5lib/filters/lint.py
+++ b/html5lib/filters/lint.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, unicode_literals
 from six import text_type
 
 from . import _base
-from ..constants import voidElements
+from ..constants import namespaces, voidElements
 
 from ..constants import spaceCharacters
 spaceCharacters = "".join(spaceCharacters)
@@ -19,17 +19,22 @@ class Filter(_base.Filter):
         for token in _base.Filter.__iter__(self):
             type = token["type"]
             if type in ("StartTag", "EmptyTag"):
+                namespace = token["namespace"]
                 name = token["name"]
+                if namespace is not None and not isinstance(namespace, text_type):
+                    raise LintError("Tag namespace is not a string or None: %(name)r" % {"name": namespace})
+                if namespace == "":
+                    raise LintError("Empty tag namespace")
                 if not isinstance(name, text_type):
                     raise LintError("Tag name is not a string: %(tag)r" % {"tag": name})
                 if not name:
                     raise LintError("Empty tag name")
-                if type == "StartTag" and name in voidElements:
+                if type == "StartTag" and (not namespace or namespace == namespaces["html"]) and name in voidElements:
                     raise LintError("Void element reported as StartTag token: %(tag)s" % {"tag": name})
-                elif type == "EmptyTag" and name not in voidElements:
+                elif type == "EmptyTag" and (not namespace or namespace == namespaces["html"]) and name not in voidElements:
                     raise LintError("Non-void element reported as EmptyTag token: %(tag)s" % {"tag": token["name"]})
                 if type == "StartTag":
-                    open_elements.append(name)
+                    open_elements.append((namespace, name))
                 for (namespace, localname), value in token["data"].items():
                     if namespace is not None and not isinstance(namespace, text_type):
                         raise LintError("Attribute namespace is not a string or None: %(name)r" % {"name": namespace})
@@ -43,15 +48,20 @@ class Filter(_base.Filter):
                         raise LintError("Attribute value is not a string: %(value)r" % {"value": value})
 
             elif type == "EndTag":
+                namespace = token["namespace"]
                 name = token["name"]
+                if namespace is not None and not isinstance(namespace, text_type):
+                    raise LintError("Tag namespace is not a string or None: %(name)r" % {"name": namespace})
+                if namespace == "":
+                    raise LintError("Empty tag namespace")
                 if not isinstance(name, text_type):
                     raise LintError("Tag name is not a string: %(tag)r" % {"tag": name})
                 if not name:
                     raise LintError("Empty tag name")
-                if name in voidElements:
+                if (not namespace or namespace == namespaces["html"]) and name in voidElements:
                     raise LintError("Void element reported as EndTag token: %(tag)s" % {"tag": name})
                 start_name = open_elements.pop()
-                if start_name != name:
+                if start_name != (namespace, name):
                     raise LintError("EndTag (%(end)s) does not match StartTag (%(start)s)" % {"end": name, "start": start_name})
 
             elif type == "Comment":

--- a/html5lib/tests/test_treewalkers.py
+++ b/html5lib/tests/test_treewalkers.py
@@ -14,6 +14,7 @@ except AttributeError:
 from .support import get_data_files, TestData, convertExpected
 
 from html5lib import html5parser, treewalkers, treebuilders, treeadapters, constants
+from html5lib.filters.lint import Filter as Lint
 
 
 treeTypes = {
@@ -91,7 +92,7 @@ class TokenTestCase(unittest.TestCase):
             p = html5parser.HTMLParser(tree=treeCls["builder"])
             document = p.parse("<html><head></head><body>a<div>b</div>c</body></html>")
             document = treeCls.get("adapter", lambda x: x)(document)
-            output = treeCls["walker"](document)
+            output = Lint(treeCls["walker"](document))
             for expectedToken, outputToken in zip(expected, output):
                 self.assertEqual(expectedToken, outputToken)
 
@@ -111,7 +112,7 @@ def runTreewalkerTest(innerHTML, input, expected, errors, treeClass):
 
     document = treeClass.get("adapter", lambda x: x)(document)
     try:
-        output = treewalkers.pprint(treeClass["walker"](document))
+        output = treewalkers.pprint(Lint(treeClass["walker"](document)))
         output = attrlist.sub(sortattrs, output)
         expected = attrlist.sub(sortattrs, convertExpected(expected))
         diff = "".join(unified_diff([line + "\n" for line in expected.splitlines()],

--- a/html5lib/tests/test_treewalkers.py
+++ b/html5lib/tests/test_treewalkers.py
@@ -78,15 +78,15 @@ class TokenTestCase(unittest.TestCase):
         expected = [
             {'data': {}, 'type': 'StartTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'html'},
             {'data': {}, 'type': 'StartTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'head'},
-            {'data': {}, 'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'head'},
+            {'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'head'},
             {'data': {}, 'type': 'StartTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'body'},
             {'data': 'a', 'type': 'Characters'},
             {'data': {}, 'type': 'StartTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'div'},
             {'data': 'b', 'type': 'Characters'},
-            {'data': {}, 'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'div'},
+            {'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'div'},
             {'data': 'c', 'type': 'Characters'},
-            {'data': {}, 'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'body'},
-            {'data': {}, 'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'html'}
+            {'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'body'},
+            {'type': 'EndTag', 'namespace': 'http://www.w3.org/1999/xhtml', 'name': 'html'}
         ]
         for treeName, treeCls in sorted(treeTypes.items()):
             p = html5parser.HTMLParser(tree=treeCls["builder"])

--- a/html5lib/treewalkers/_base.py
+++ b/html5lib/treewalkers/_base.py
@@ -31,11 +31,6 @@ def to_text(s, blank_if_none=True):
         return text_type(s)
 
 
-def is_text_or_none(string):
-    """Wrapper around isinstance(string_types) or is None"""
-    return string is None or isinstance(string, string_types)
-
-
 class TreeWalker(object):
     def __init__(self, tree):
         self.tree = tree
@@ -47,13 +42,6 @@ class TreeWalker(object):
         return {"type": "SerializeError", "data": msg}
 
     def emptyTag(self, namespace, name, attrs, hasChildren=False):
-        assert namespace is None or isinstance(namespace, string_types), type(namespace)
-        assert isinstance(name, string_types), type(name)
-        assert all((namespace is None or isinstance(namespace, string_types)) and
-                   isinstance(name, string_types) and
-                   isinstance(value, string_types)
-                   for (namespace, name), value in attrs.items())
-
         yield {"type": "EmptyTag", "name": to_text(name, False),
                "namespace": to_text(namespace),
                "data": attrs}
@@ -61,13 +49,6 @@ class TreeWalker(object):
             yield self.error("Void element has children")
 
     def startTag(self, namespace, name, attrs):
-        assert namespace is None or isinstance(namespace, string_types), type(namespace)
-        assert isinstance(name, string_types), type(name)
-        assert all((namespace is None or isinstance(namespace, string_types)) and
-                   isinstance(name, string_types) and
-                   isinstance(value, string_types)
-                   for (namespace, name), value in attrs.items())
-
         return {"type": "StartTag",
                 "name": text_type(name),
                 "namespace": to_text(namespace),
@@ -76,17 +57,12 @@ class TreeWalker(object):
                              for (namespace, name), value in attrs.items())}
 
     def endTag(self, namespace, name):
-        assert namespace is None or isinstance(namespace, string_types), type(namespace)
-        assert isinstance(name, string_types), type(namespace)
-
         return {"type": "EndTag",
                 "name": to_text(name, False),
                 "namespace": to_text(namespace),
                 "data": {}}
 
     def text(self, data):
-        assert isinstance(data, string_types), type(data)
-
         data = to_text(data)
         middle = data.lstrip(spaceCharacters)
         left = data[:len(data) - len(middle)]
@@ -101,15 +77,9 @@ class TreeWalker(object):
             yield {"type": "SpaceCharacters", "data": right}
 
     def comment(self, data):
-        assert isinstance(data, string_types), type(data)
-
         return {"type": "Comment", "data": text_type(data)}
 
     def doctype(self, name, publicId=None, systemId=None, correct=True):
-        assert is_text_or_none(name), type(name)
-        assert is_text_or_none(publicId), type(publicId)
-        assert is_text_or_none(systemId), type(systemId)
-
         return {"type": "Doctype",
                 "name": to_text(name),
                 "publicId": to_text(publicId),
@@ -117,8 +87,6 @@ class TreeWalker(object):
                 "correct": to_text(correct)}
 
     def entity(self, name):
-        assert isinstance(name, string_types), type(name)
-
         return {"type": "Entity", "name": text_type(name)}
 
     def unknown(self, nodeType):

--- a/html5lib/treewalkers/_base.py
+++ b/html5lib/treewalkers/_base.py
@@ -62,12 +62,11 @@ class TreeWalker(object):
     def comment(self, data):
         return {"type": "Comment", "data": data}
 
-    def doctype(self, name, publicId=None, systemId=None, correct=True):
+    def doctype(self, name, publicId=None, systemId=None):
         return {"type": "Doctype",
                 "name": name,
                 "publicId": publicId,
-                "systemId": systemId,
-                "correct": correct}
+                "systemId": systemId}
 
     def entity(self, name):
         return {"type": "Entity", "name": name}

--- a/html5lib/treewalkers/_base.py
+++ b/html5lib/treewalkers/_base.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, unicode_literals
-from six import text_type, string_types
 
 from xml.dom import Node
 from ..constants import namespaces, voidElements, spaceCharacters
@@ -18,19 +17,6 @@ UNKNOWN = "<#UNKNOWN#>"
 spaceCharacters = "".join(spaceCharacters)
 
 
-def to_text(s, blank_if_none=True):
-    """Wrapper around six.text_type to convert None to empty string"""
-    if s is None:
-        if blank_if_none:
-            return ""
-        else:
-            return None
-    elif isinstance(s, text_type):
-        return s
-    else:
-        return text_type(s)
-
-
 class TreeWalker(object):
     def __init__(self, tree):
         self.tree = tree
@@ -42,28 +28,26 @@ class TreeWalker(object):
         return {"type": "SerializeError", "data": msg}
 
     def emptyTag(self, namespace, name, attrs, hasChildren=False):
-        yield {"type": "EmptyTag", "name": to_text(name, False),
-               "namespace": to_text(namespace),
+        yield {"type": "EmptyTag", "name": name,
+               "namespace": namespace,
                "data": attrs}
         if hasChildren:
             yield self.error("Void element has children")
 
     def startTag(self, namespace, name, attrs):
         return {"type": "StartTag",
-                "name": text_type(name),
-                "namespace": to_text(namespace),
-                "data": dict(((to_text(namespace, False), to_text(name)),
-                              to_text(value, False))
-                             for (namespace, name), value in attrs.items())}
+                "name": name,
+                "namespace": namespace,
+                "data": attrs}
 
     def endTag(self, namespace, name):
         return {"type": "EndTag",
-                "name": to_text(name, False),
-                "namespace": to_text(namespace),
+                "name": name,
+                "namespace": namespace,
                 "data": {}}
 
     def text(self, data):
-        data = to_text(data)
+        data = data
         middle = data.lstrip(spaceCharacters)
         left = data[:len(data) - len(middle)]
         if left:
@@ -77,17 +61,17 @@ class TreeWalker(object):
             yield {"type": "SpaceCharacters", "data": right}
 
     def comment(self, data):
-        return {"type": "Comment", "data": text_type(data)}
+        return {"type": "Comment", "data": data}
 
     def doctype(self, name, publicId=None, systemId=None, correct=True):
         return {"type": "Doctype",
-                "name": to_text(name),
-                "publicId": to_text(publicId),
-                "systemId": to_text(systemId),
-                "correct": to_text(correct)}
+                "name": name,
+                "publicId": publicId,
+                "systemId": systemId,
+                "correct": correct}
 
     def entity(self, name):
-        return {"type": "Entity", "name": text_type(name)}
+        return {"type": "Entity", "name": name}
 
     def unknown(self, nodeType):
         return self.error("Unknown node type: " + nodeType)

--- a/html5lib/treewalkers/_base.py
+++ b/html5lib/treewalkers/_base.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, unicode_literals
 from six import text_type, string_types
 
 from xml.dom import Node
-from ..constants import voidElements, spaceCharacters
+from ..constants import namespaces, voidElements, spaceCharacters
 
 __all__ = ["DOCUMENT", "DOCTYPE", "TEXT", "ELEMENT", "COMMENT", "ENTITY", "UNKNOWN",
            "TreeWalker", "NonRecursiveTreeWalker"]
@@ -154,7 +154,7 @@ class NonRecursiveTreeWalker(TreeWalker):
 
             elif type == ELEMENT:
                 namespace, name, attributes, hasChildren = details
-                if name in voidElements:
+                if (not namespace or namespace == namespaces["html"]) and name in voidElements:
                     for token in self.emptyTag(namespace, name, attributes,
                                                hasChildren):
                         yield token
@@ -187,7 +187,7 @@ class NonRecursiveTreeWalker(TreeWalker):
                     type, details = details[0], details[1:]
                     if type == ELEMENT:
                         namespace, name, attributes, hasChildren = details
-                        if name not in voidElements:
+                        if (namespace and namespace != namespaces["html"]) or name not in voidElements:
                             yield self.endTag(namespace, name)
                     if self.tree is currentNode:
                         currentNode = None

--- a/html5lib/treewalkers/_base.py
+++ b/html5lib/treewalkers/_base.py
@@ -43,8 +43,7 @@ class TreeWalker(object):
     def endTag(self, namespace, name):
         return {"type": "EndTag",
                 "name": name,
-                "namespace": namespace,
-                "data": {}}
+                "namespace": namespace}
 
     def text(self, data):
         data = data

--- a/html5lib/treewalkers/genshistream.py
+++ b/html5lib/treewalkers/genshistream.py
@@ -48,7 +48,7 @@ class TreeWalker(_base.TreeWalker):
         elif kind == END:
             name = data.localname
             namespace = data.namespace
-            if name not in voidElements:
+            if namespace != namespaces["html"] or name not in voidElements:
                 yield self.endTag(namespace, name)
 
         elif kind == COMMENT:

--- a/html5lib/treewalkers/lxmletree.py
+++ b/html5lib/treewalkers/lxmletree.py
@@ -139,7 +139,7 @@ class TreeWalker(_base.NonRecursiveTreeWalker):
             return _base.DOCTYPE, node.name, node.public_id, node.system_id
 
         elif isinstance(node, FragmentWrapper) and not hasattr(node, "tag"):
-            return _base.TEXT, node.obj
+            return _base.TEXT, ensure_str(node.obj)
 
         elif node.tag == etree.Comment:
             return _base.COMMENT, ensure_str(node.text)

--- a/html5lib/treewalkers/lxmletree.py
+++ b/html5lib/treewalkers/lxmletree.py
@@ -118,8 +118,10 @@ class FragmentWrapper(object):
 class TreeWalker(_base.NonRecursiveTreeWalker):
     def __init__(self, tree):
         if hasattr(tree, "getroot"):
+            self.fragmentChildren = set()
             tree = Root(tree)
         elif isinstance(tree, list):
+            self.fragmentChildren = set(tree)
             tree = FragmentRoot(tree)
         _base.NonRecursiveTreeWalker.__init__(self, tree)
         self.filter = ihatexml.InfosetFilter()
@@ -197,5 +199,7 @@ class TreeWalker(_base.NonRecursiveTreeWalker):
             if key == "text":
                 return node
             # else: fallback to "normal" processing
+        elif node in self.fragmentChildren:
+            return None
 
         return node.getparent()


### PR DESCRIPTION
This makes the lint filter actually ensure tree walker implementations follow their supposed API, runs all of the tree walker tests through the filter, and fixes a number of bugs it shows up.