### PR TITLE
Fix python implementation marker for setuptools 2.20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(name='html5lib',
 
           # A conditional extra will only install these items when the extra is
           # requested and the condition matches.
-          "datrie:python_implementation == 'CPython'": ["datrie"],
-          "lxml:python_implementation == 'CPython'": ["lxml"],
+          "datrie:platform_python_implementation == 'CPython'": ["datrie"],
+          "lxml:platform_python_implementation == 'CPython'": ["lxml"],
 
           # Standard extras, will be installed when the extra is requested.
           "genshi": ["genshi"],
@@ -77,6 +77,6 @@ setup(name='html5lib',
           # extra that will be installed whenever the condition matches and the
           # all extra is requested.
           "all": ["genshi", "charade"],
-          "all:python_implementation == 'CPython'": ["datrie", "lxml"],
+          "all:platform_python_implementation == 'CPython'": ["datrie", "lxml"],
       },
       )


### PR DESCRIPTION
Otherwise setup.py fail with `error in html5lib setup command: Invalid environment marker: python_implementation == 'CPython'`