### PR TITLE
Use the platform.python_implementation because it's the most compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(name='html5lib',
 
           # A conditional extra will only install these items when the extra is
           # requested and the condition matches.
-          "datrie:platform_python_implementation == 'CPython'": ["datrie"],
-          "lxml:platform_python_implementation == 'CPython'": ["lxml"],
+          "datrie:platform.python_implementation == 'CPython'": ["datrie"],
+          "lxml:platform.python_implementation == 'CPython'": ["lxml"],
 
           # Standard extras, will be installed when the extra is requested.
           "genshi": ["genshi"],
@@ -77,6 +77,6 @@ setup(name='html5lib',
           # extra that will be installed whenever the condition matches and the
           # all extra is requested.
           "all": ["genshi", "charade"],
-          "all:platform_python_implementation == 'CPython'": ["datrie", "lxml"],
+          "all:platform.python_implementation == 'CPython'": ["datrie", "lxml"],
       },
       )


### PR DESCRIPTION
See <https://github.com/pypa/packaging/issues/72#issuecomment-213826903> for a discussion of the various setuptools different aliases support. This means we don't work with 20.2 to 20.6 (released mid-Feb till late-Mar 2016).