### PR TITLE
lxml should only ever return an ASCII string as a str

### DIFF
--- a/html5lib/treewalkers/lxmletree.py
+++ b/html5lib/treewalkers/lxmletree.py
@@ -15,7 +15,7 @@ def ensure_str(s):
     elif isinstance(s, text_type):
         return s
     else:
-        return s.decode("utf-8", "strict")
+        return s.decode("ascii", "strict")
 
 
 class Root(object):


### PR DESCRIPTION
See <http://lxml.de/FAQ.html#why-does-lxml-sometimes-return-str-values-for-text-in-python-2>