### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -219,7 +219,7 @@ Released on May 17, 2013
 
 * Test harness has been improved and now depends on ``nose``.
 
-* Documentation updated and moved to http://html5lib.readthedocs.org/.
+* Documentation updated and moved to https://html5lib.readthedocs.io/.
 
 
 0.95

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ format:
   parser = html5lib.HTMLParser(tree=html5lib.getTreeBuilder("dom"))
   minidom_document = parser.parse("<p>Hello World!")
 
-More documentation is available at http://html5lib.readthedocs.org/.
+More documentation is available at https://html5lib.readthedocs.io/.
 
 
 Installation


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.