### PR TITLE
Try dealing with the backwards incompatible changes in setuptools again

### DIFF
--- a/requirements-install.sh
+++ b/requirements-install.sh
@@ -6,7 +6,7 @@ if [[ $USE_OPTIONAL != "true" && $USE_OPTIONAL != "false" ]]; then
 fi
 
 # Make sure we're running setuptools >= 18.5
-pip install -U pip setuptools
+pip install -U pip setuptools>=18.5
 
 pip install -U -r requirements-test.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 six
 webencodings
 ordereddict ; python_version < '2.7'
+setuptools>=18.5

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,17 @@
+from __future__ import print_function
+
 import ast
 import codecs
+import sys
 
 from os.path import join, dirname
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, __version__ as setuptools_version
+from pkg_resources import parse_version
 
+if parse_version(setuptools_version) < parse_version("18.5"):
+    print("html5lib requires setuptools version 18.5 or above; "
+          "please upgrade before installing (you have %s)" % setuptools_version)
+    sys.exit(1)
 
 classifiers = [
     'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(name='html5lib',
       install_requires=[
           'six',
           'webencodings',
+          'setuptools>=18.5'
       ],
       extras_require={
           # A empty extra that only has a conditional marker will be
@@ -60,8 +61,8 @@ setup(name='html5lib',
 
           # A conditional extra will only install these items when the extra is
           # requested and the condition matches.
-          "datrie:platform.python_implementation == 'CPython'": ["datrie"],
-          "lxml:platform.python_implementation == 'CPython'": ["lxml"],
+          "datrie:platform_python_implementation == 'CPython'": ["datrie"],
+          "lxml:platform_python_implementation == 'CPython'": ["lxml"],
 
           # Standard extras, will be installed when the extra is requested.
           "genshi": ["genshi"],
@@ -72,6 +73,6 @@ setup(name='html5lib',
           # extra that will be installed whenever the condition matches and the
           # all extra is requested.
           "all": ["genshi", "chardet>=2.2"],
-          "all:platform.python_implementation == 'CPython'": ["datrie", "lxml"],
+          "all:platform_python_implementation == 'CPython'": ["datrie", "lxml"],
       },
       )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with codecs.open(join(here, 'README.rst'), 'r', 'utf8') as readme_file:
         long_description = readme_file.read() + '\n' + changes_file.read()
 
 version = None
-with open(join("html5lib", "__init__.py"), "rb") as init_file:
+with open(join(here, "html5lib", "__init__.py"), "rb") as init_file:
     t = ast.parse(init_file.read(), filename="__init__.py", mode="exec")
     assert isinstance(t, ast.Module)
     assignments = filter(lambda x: isinstance(x, ast.Assign), t.body)


### PR DESCRIPTION
This tries to address #231 again, reverting to platform_python_implementation. This should work everywhere with setuptools 18.5 above; see #231 for more discussion of this.