### PR TITLE
Monkeypatch pkg_resources to always use _markerlib

### DIFF
--- a/requirements-install.sh
+++ b/requirements-install.sh
@@ -5,9 +5,6 @@ if [[ $USE_OPTIONAL != "true" && $USE_OPTIONAL != "false" ]]; then
   exit 1
 fi
 
-# Make sure we're running setuptools >= 18.5
-pip install -U pip setuptools>=18.5
-
 pip install -U -r requirements-test.txt
 
 if [[ $USE_OPTIONAL == "true" ]]; then

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,3 @@ flake8
 pytest
 pytest-expect>=1.1,<2.0
 mock
-ordereddict ; python_version < '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 six
 webencodings
 ordereddict ; python_version < '2.7'
-setuptools>=18.5


### PR DESCRIPTION
Prior to setuptools 20.10.0 there is patchy support for environment markers,
and setup.py fails while parsing them.
html5lib requires at least setuptools 18.5 for its environment markers.

However, @gsnedders developed a way to monkey patch pkg_resources
so that it always uses _markerlib, which allows all environment markers
to be used for any version of setuptools.  Some patching of _markerlib
is also required so that it works on Python 3 also.

On removing the dependency for setuptools>=18.5, pip partially fails on
Python 2.6 with an error `Double requirement given: ordereddict`
and does not install the requirements.txt.
Fixed by removing ordereddict from requirements-test.txt