### PR TITLE
Allows uppercase color codes in style

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -42,3 +42,4 @@ Patches and suggestions
 - Michael[tm] Smith
 - Marc Abramowitz
 - Jon Dufresne
+- Komal Dembla

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Change Log
 ----------
 
+0.999999999/1.0b11
+~~~~~~~~~~~~~~~~~~
+
+Released on XXX
+
+* Adds uppercase check (A-F) in the css regex to allow sanitizer to pass css
+  of the format: border: 1px solid #A2A2A2.
+
+
 0.999999999/1.0b10
 ~~~~~~~~~~~~~~~~~~
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2013 James Graham and other contributors
+Copyright (c) 2006-2013 James Graham, Google Inc. and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2013 James Graham, Google Inc. and other contributors
+Copyright (c) 2006-2013 James Graham and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/html5lib/filters/sanitizer.py
+++ b/html5lib/filters/sanitizer.py
@@ -855,7 +855,7 @@ class Filter(base.Filter):
                                                 'padding']:
                 for keyword in value.split():
                     if keyword not in self.allowed_css_keywords and \
-                            not re.match("^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$", keyword):  # noqa
+                            not re.match("^(#[0-9a-fA-F]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$", keyword):  # noqa
                         break
                 else:
                     clean.append(prop + ': ' + value + ';')

--- a/html5lib/tests/test_sanitizer.py
+++ b/html5lib/tests/test_sanitizer.py
@@ -117,7 +117,5 @@ def test_sanitizer():
 
 def test_should_handle_uppercase_color_codes_in_style():
     sanitized = sanitize_html("<p style=\"border: 1px solid #A2A2A2;\"></p>")
-    print sanitized
     expected = '<p style=\"border: 1px solid #A2A2A2;\"></p>'
-    print expected
     assert expected == sanitized

--- a/html5lib/tests/test_sanitizer.py
+++ b/html5lib/tests/test_sanitizer.py
@@ -113,3 +113,11 @@ def test_sanitizer():
         yield (runSanitizerTest, "test_should_allow_uppercase_%s_uris" % protocol,
                "<img src=\"%s:%s\">foo</a>" % (protocol, rest_of_uri),
                """<img src="%s:%s">foo</a>""" % (protocol, rest_of_uri))
+
+
+def test_should_handle_uppercase_color_codes_in_style():
+    sanitized = sanitize_html("<p style=\"border: 1px solid #A2A2A2;\"></p>")
+    print sanitized
+    expected = '<p style=\"border: 1px solid #A2A2A2;\"></p>'
+    print expected
+    assert expected == sanitized


### PR DESCRIPTION
Adds uppercase check (A-F) in the css regex to pass css of the following format:
 border-top: 2px #DA4534 solid;
