### PR TITLE
Require flake8 to be < 3.0 for Python 2.6 support

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-flake8
+flake8<3.0
 pytest
 pytest-expect>=1.1,<2.0
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = {py26,py27,py33,py34,py35,pypy}-{base,optional}
 
 [testenv]
 deps =
-  flake8
+  flake8<3.0
   pytest
   pytest-expect>=1.1,<2.0
   mock


### PR DESCRIPTION
Fixes #290.
