### PR TITLE
Update Travis to use tox, and add Appveyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,18 @@
+# To activate, change the Appveyor settings to use `.appveyor.yml`.
+init:
+  - SET PATH=C:\\Python27\\Scripts\\;%PATH%"
+  - SET COVERAGE_RUN_OPTIONS="--parallel-mode"
+
+install:
+  - git submodule update --init --recursive
+  - python -m pip install tox codecov
+
+build: off
+
+test_script:
+  # Avoid py35-optional, as pypi does not have lxml wheels for py35
+  - python -m tox -e "py35-base,{py26,py27,py33,py34}-{base,optional}"
+
+on_success:
+  - coverage combine
+  - codecov

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@ ignore=tests
 
 [MESSAGES CONTROL]
 # messages up to fixme should probably be fixed somehow
-disable = redefined-builtin,attribute-defined-outside-init,anomalous-backslash-in-string,no-self-use,redefined-outer-name,bad-continuation,wrong-import-order,superfluous-parens,no-member,duplicate-code,super-init-not-called,abstract-method,property-on-old-class,wrong-import-position,no-name-in-module,no-init,bad-mcs-classmethod-argument,bad-classmethod-argument,fixme,invalid-name,import-error,too-few-public-methods,too-many-ancestors,too-many-arguments,too-many-boolean-expressions,too-many-branches,too-many-instance-attributes,too-many-locals,too-many-lines,too-many-public-methods,too-many-return-statements,too-many-statements,missing-docstring,line-too-long,locally-disabled,locally-enabled,bad-builtin,deprecated-lambda
+disable = redefined-builtin,attribute-defined-outside-init,anomalous-backslash-in-string,no-self-use,redefined-outer-name,bad-continuation,wrong-import-order,superfluous-parens,no-member,duplicate-code,super-init-not-called,abstract-method,property-on-old-class,wrong-import-position,no-name-in-module,no-init,bad-mcs-classmethod-argument,bad-classmethod-argument,fixme,invalid-name,import-error,too-few-public-methods,too-many-ancestors,too-many-arguments,too-many-boolean-expressions,too-many-branches,too-many-instance-attributes,too-many-locals,too-many-lines,too-many-public-methods,too-many-return-statements,too-many-statements,missing-docstring,line-too-long,locally-disabled,locally-enabled,bad-builtin,deprecated-lambda,bad-option-value,star-args,abstract-class-little-used,abstract-class-not-used
 
 [FORMAT]
 max-line-length=139

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,22 +14,17 @@ cache:
     - $HOME/.cache/pip
 
 env:
-  - USE_OPTIONAL=true
-  - USE_OPTIONAL=false
-
-before_install:
-  - git submodule update --init --recursive
+  - TOXENV=optional
+  - TOXENV=base
 
 install:
-  - bash requirements-install.sh
+  - pip install tox codecov
 
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == pypy* ]]; then py.test; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage run -m pytest; fi
-  - bash flake8-run.sh
+  - tox
 
 after_script:
   - python debug-info.py
 
 after_success:
-  - if [[ $TRAVIS_PYTHON_VERSION != pypy* ]]; then coverage combine && codecov; fi
+  - codecov

--- a/flake8-run.sh
+++ b/flake8-run.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-if [[ ! -x $(which flake8) ]]; then
-  echo "fatal: flake8 not found on $PATH. Exiting."
-  exit 1
-fi
-
-flake8 `dirname $0`
-exit $?

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -10,7 +10,11 @@ chardet>=2.2
 
 # lxml is supported with its own treebuilder ("lxml") and otherwise
 # uses the standard ElementTree support
-lxml ; platform_python_implementation == 'CPython'
+lxml ; platform_python_implementation == 'CPython' and sys_platform != 'win32'
+lxml==3.6.0 ; platform_python_implementation == 'CPython' and sys_platform == 'win32' and python_version <= '3.4'
+lxml==3.6.0 ; platform_python_implementation == 'CPython' and sys_platform == 'win_amd64' and python_version <= '3.4'
+lxml ; platform_python_implementation == 'CPython' and sys_platform == 'win32' and python_version >= '3.5'
+lxml ; platform_python_implementation == 'CPython' and sys_platform == 'win_amd64' and python_version >= '3.5'
 
 # DATrie can be used in place of our Python trie implementation for
 # slightly better parsing performance.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,14 @@
 -r requirements.txt
 
+tox
+
 flake8<3.0
+
+pylint==1.6.4 ; python_version > '2.6'
+pylint==1.3.1 ; python_version <= '2.6'
+astroid==1.3.5 ; python_version <= '2.6'
+
 pytest
+coverage
 pytest-expect>=1.1,<2.0
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,15 @@ envlist = {py26,py27,py33,py34,py35,pypy}-{base,optional}
 
 [testenv]
 deps =
-  flake8<3.0
-  pytest
-  pytest-expect>=1.1,<2.0
-  mock
-  base: six
-  base: webencodings
-  py26-base: ordereddict
+  -r{toxinidir}/requirements-test.txt
   optional: -r{toxinidir}/requirements-optional.txt
 
+passenv =
+  COVERAGE_RUN_OPTIONS
 commands =
-  {envbindir}/py.test
-  {toxinidir}/flake8-run.sh
+  coverage run {env:COVERAGE_RUN_OPTIONS:} -m pytest
+  flake8
+  pylint --rcfile={toxinidir}/.pylintrc html5lib
+
+[flake8]
+exclude = ./.tox


### PR DESCRIPTION
Update tox.ini to utilise requirements-test.txt, and run pylint.
Require lxml 3.6.0 on Windows as it has wheels available for 2.6-3.4.

Also enables coverage for PyPy on Travis.
