### PR TITLE
Allow disabling the stripping of HTML comments in sanitizer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Change Log
 ----------
 
+UPCOMING
+~~~~~~~~
+
+* Added ``strip_comments`` parameter to sanitizer. When ``False`` HTML comments
+  will not be stripped.
+
 0.999999999/1.0b10
 ~~~~~~~~~~~~~~~~~~
 

--- a/html5lib/filters/sanitizer.py
+++ b/html5lib/filters/sanitizer.py
@@ -717,7 +717,8 @@ class Filter(base.Filter):
                  allowed_content_types=allowed_content_types,
                  attr_val_is_uri=attr_val_is_uri,
                  svg_attr_val_allows_ref=svg_attr_val_allows_ref,
-                 svg_allow_local_href=svg_allow_local_href):
+                 svg_allow_local_href=svg_allow_local_href,
+                 strip_comments=True):
         super(Filter, self).__init__(source)
         self.allowed_elements = allowed_elements
         self.allowed_attributes = allowed_attributes
@@ -729,6 +730,7 @@ class Filter(base.Filter):
         self.attr_val_is_uri = attr_val_is_uri
         self.svg_attr_val_allows_ref = svg_attr_val_allows_ref
         self.svg_allow_local_href = svg_allow_local_href
+        self.strip_comments = strip_comments
 
     def __iter__(self):
         for token in base.Filter.__iter__(self):
@@ -760,7 +762,7 @@ class Filter(base.Filter):
                 return self.allowed_token(token)
             else:
                 return self.disallowed_token(token)
-        elif token_type == "Comment":
+        elif token_type == "Comment" and self.strip_comments:
             pass
         else:
             return token

--- a/html5lib/tests/test_sanitizer.py
+++ b/html5lib/tests/test_sanitizer.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from html5lib import constants, parseFragment, serialize
+from html5lib import constants, getTreeWalker, parseFragment, serialize
 from html5lib.filters import sanitizer
+from html5lib.serializer import HTMLSerializer
 
 
 def runSanitizerTest(_, expected, input):
@@ -113,3 +114,15 @@ def test_sanitizer():
         yield (runSanitizerTest, "test_should_allow_uppercase_%s_uris" % protocol,
                "<img src=\"%s:%s\">foo</a>" % (protocol, rest_of_uri),
                """<img src="%s:%s">foo</a>""" % (protocol, rest_of_uri))
+
+
+def test_strip_comments():
+    comment = '<!-- this is a comment -->'
+    assert sanitize_html(comment) == ''
+
+    parsed = parseFragment(comment)
+    walker = getTreeWalker('etree')
+    stream = walker(parsed)
+    sanitized = sanitizer.Filter(stream, strip_comments=False)
+    s = HTMLSerializer()
+    assert s.render(sanitized) == comment


### PR DESCRIPTION
Can be used by libraries like
[bleach](https://github.com/mozilla/bleach) to upgrade to the new
sanitizer API.