### PR TITLE
Declare implicit dependency on Six 1.9 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
 env:
   - USE_OPTIONAL=true
   - USE_OPTIONAL=false
+  - SIX_VERSION=1.9 USE_OPTIONAL=true
 
 install:
   - bash requirements-install.sh

--- a/requirements-install.sh
+++ b/requirements-install.sh
@@ -11,6 +11,10 @@ if [[ $USE_OPTIONAL == "true" ]]; then
   pip install -U -r requirements-optional.txt
 fi
 
+if [[ $SIX_VERSION != "false" ]]; then
+  pip install six==$SIX_VERSION
+fi
+
 if [[ $CI == "true" ]]; then
   pip install -U codecov
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-six
+six>=1.9
 webencodings
 ordereddict ; python_version < '2.7'

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(name='html5lib',
       maintainer_email='james@hoppipolla.co.uk',
       packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
       install_requires=[
-          'six',
+          'six>=1.9',
           'webencodings',
       ],
       extras_require={


### PR DESCRIPTION
This project uses a syntax for importing urllib.parse from six which was introduced in Six version 1.4



The import can be found [here](https://github.com/html5lib/html5lib-python/blob/master/html5lib/filters/sanitizer.py#L6)

The relevant change in Six can be found [here](https://bitbucket.org/gutworth/six/commits/1f2c7f5d14be9027d180aa00138a1d29c8f48a6f?at=1.4.0#Lsix.pyT188)

This can cause an issue if a project has a previous version of Six (say version 1.3) installed when installing html5lib

EDIT:
importing `viewkeys` in html5parser.py requires six 1.9

