### PR TITLE
Remove redundant submodule update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ env:
   - USE_OPTIONAL=true
   - USE_OPTIONAL=false
 
-before_install:
-  - git submodule update --init --recursive
-
 install:
   - bash requirements-install.sh
 


### PR DESCRIPTION
Travis CI automatically updates submodules during initialisation.