### PR TITLE
Bump version to something readable + semver

### DIFF
--- a/html5lib/__init__.py
+++ b/html5lib/__init__.py
@@ -22,4 +22,4 @@ __all__ = ["HTMLParser", "parse", "parseFragment", "getTreeBuilder",
            "getTreeWalker", "serialize"]
 
 # this has to be at the top level, see how setup.py parses this
-__version__ = "0.9999999999-dev"
+__version__ = "0.1.0-dev"


### PR DESCRIPTION
Counting the 9s is a bit tiring, particularely when debugging version conflicts. I suppose this is because html5lib is not judged mature enough to be released as 1.0. This patch proposes moving from 0.999999 to 0.1.0 and at the same time proposes to adopt the semver standard.