### PR TITLE
Fix tox.ini to allow specifying pytest tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,5 @@ deps =
   optional: -r{toxinidir}/requirements-optional.txt
 
 commands =
-  {envbindir}/py.test
+  {envbindir}/py.test {posargs}
   {toxinidir}/flake8-run.sh


### PR DESCRIPTION
This fixes tox.ini so that you can pass arguments to py.test.

For example:

```
    tox -e py34-base html5lib/tests/test_serializer.py
```

will now only run the serializer tests.

```
    tox -e py34-base -- -vv
```

will run with super verbose mode and tons of data will go flying by in your
terminal.