### PR TITLE
Fix Travis CI builds on Python 3.4

### DIFF
--- a/requirements-install.sh
+++ b/requirements-install.sh
@@ -1,15 +1,15 @@
 #!/bin/bash -ex
 
-pip install -U -r requirements-test.txt
-
-if [[ $USE_OPTIONAL == "true" ]]; then
-  pip install -U -r requirements-optional.txt
-fi
-
 if [[ $SIX_VERSION ]]; then
   pip install six==$SIX_VERSION
 fi
 
+pip install -r requirements-test.txt
+
+if [[ $USE_OPTIONAL == "true" ]]; then
+  pip install -r requirements-optional.txt
+fi
+
 if [[ $CI == "true" ]]; then
-  pip install -U codecov
+  pip install codecov
 fi


### PR DESCRIPTION
Avoid passing `-U` to `pip install` commands. It causes the six package to upgrade, which fails on the Travis 3.4 image. I cannot reproduce this locally, so I'm left to conclude that the Travis Python 3.4 image is corrupt in some way. The installed six package is perfectly fine for testing, so use it without upgrading. All builds now pass.

Install six package first to avoid upgrading it then downgrading it in some test configurations.