### PR TITLE
Fail hard with tracebacks if pytest-expect isn't working

### DIFF
--- a/html5lib/tests/conftest.py
+++ b/html5lib/tests/conftest.py
@@ -1,4 +1,6 @@
+from __future__ import print_function
 import os.path
+import sys
 
 import pkg_resources
 import pytest
@@ -13,6 +15,26 @@ _testdata = os.path.join(_dir, "testdata")
 _tree_construction = os.path.join(_testdata, "tree-construction")
 _tokenizer = os.path.join(_testdata, "tokenizer")
 _sanitizer_testdata = os.path.join(_dir, "sanitizer-testdata")
+
+
+def fail_if_missing_pytest_expect():
+    """Throws an exception halting pytest if pytest-expect isn't working"""
+    try:
+        from pytest_expect import expect  # noqa
+    except ImportError:
+        header = '*' * 78
+        print(
+            '\n' +
+            header + '\n' +
+            'ERROR: Either pytest-expect or its dependency u-msgpack-python is not\n' +
+            'installed. Please install them both before running pytest.\n' +
+            header + '\n',
+            file=sys.stderr
+        )
+        raise
+
+
+fail_if_missing_pytest_expect()
 
 
 def pytest_configure(config):


### PR DESCRIPTION
Fixes #329 

If you run pytest without pytest-expect or u-msgpack-python, then it'll show something like this:

```
$ pytest
======================================================= test session starts ========================================================
platform linux2 -- Python 2.7.13, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
rootdir: /home/willkg/mozilla/html5lib-python, inifile: pytest.ini

******************************************************************************
ERROR: Either pytest-expect or its dependency u-msgpack-python is not
installed. Please install them both before running pytest.
******************************************************************************

collected 0 items / 1 errors                                                                                                        

===================================================== short test summary info ======================================================
ERROR 
============================================================== ERRORS ==============================================================
________________________________________________________ ERROR collecting  _________________________________________________________
../../.virtualenvs/html5lib/local/lib/python2.7/site-packages/py/_path/common.py:372: in visit
    for x in Visitor(fil, rec, ignore, bf, sort).gen(self):
../../.virtualenvs/html5lib/local/lib/python2.7/site-packages/py/_path/common.py:421: in gen
    for p in self.gen(subdir):
../../.virtualenvs/html5lib/local/lib/python2.7/site-packages/py/_path/common.py:411: in gen
    if p.check(dir=1) and (rec is None or rec(p))])
../../.virtualenvs/html5lib/local/lib/python2.7/site-packages/_pytest/main.py:728: in _recurse
    ihook = self.gethookproxy(path)
../../.virtualenvs/html5lib/local/lib/python2.7/site-packages/_pytest/main.py:632: in gethookproxy
    my_conftestmodules = pm._getconftestmodules(fspath)
../../.virtualenvs/html5lib/local/lib/python2.7/site-packages/_pytest/config.py:356: in _getconftestmodules
    mod = self._importconftest(conftestpath)
../../.virtualenvs/html5lib/local/lib/python2.7/site-packages/_pytest/config.py:381: in _importconftest
    raise ConftestImportFailure(conftestpath, sys.exc_info())
E   ConftestImportFailure: ImportError('No module named umsgpack',)
E     File "/home/willkg/.virtualenvs/html5lib/local/lib/python2.7/site-packages/_pytest/assertion/rewrite.py", line 212, in load_module
E       py.builtin.exec_(co, mod.__dict__)
E     File "/home/willkg/.virtualenvs/html5lib/local/lib/python2.7/site-packages/py/_builtin.py", line 221, in exec_
E       exec2(obj, globals, locals)
E     File "<string>", line 7, in exec2
E     File "/home/willkg/mozilla/html5lib-python/html5lib/tests/conftest.py", line 37, in <module>
E       fail_if_missing_pytest_expect()
E     File "/home/willkg/mozilla/html5lib-python/html5lib/tests/conftest.py", line 23, in fail_if_missing_pytest_expect
E       from pytest_expect import expect  # noqa
E     File "/home/willkg/.virtualenvs/html5lib/local/lib/python2.7/site-packages/_pytest/assertion/rewrite.py", line 212, in load_module
E       py.builtin.exec_(co, mod.__dict__)
E     File "/home/willkg/.virtualenvs/html5lib/local/lib/python2.7/site-packages/py/_builtin.py", line 221, in exec_
E       exec2(obj, globals, locals)
E     File "<string>", line 7, in exec2
E     File "/home/willkg/.virtualenvs/html5lib/local/lib/python2.7/site-packages/pytest_expect/expect.py", line 18, in <module>
E       import umsgpack
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
===================================================== 1 error in 0.24 seconds ======================================================
```