### PR TITLE
Remove redundant <=2.6 code

### DIFF
--- a/html5lib/_utils.py
+++ b/html5lib/_utils.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, unicode_literals
 
-import sys
 from types import ModuleType
 
 from six import text_type
@@ -13,10 +12,8 @@ except ImportError:
 
 __all__ = ["default_etree", "MethodDispatcher", "isSurrogatePair",
            "surrogatePairToCodepoint", "moduleFactoryFactory",
-           "supports_lone_surrogates", "PY27"]
+           "supports_lone_surrogates"]
 
-
-PY27 = sys.version_info[0] == 2 and sys.version_info[1] >= 7
 
 # Platforms not supporting lone surrogates (\uD800-\uDFFF) should be
 # caught by the below test. In general this would be any platform

--- a/html5lib/html5parser.py
+++ b/html5lib/html5parser.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, unicode_literals
-from six import with_metaclass, viewkeys, PY3
+from six import with_metaclass, viewkeys
 
 import types
 from collections import OrderedDict
@@ -2707,10 +2707,7 @@ def getPhases(debug):
 
 
 def adjust_attributes(token, replacements):
-    if PY3 or _utils.PY27:
-        needs_adjustment = viewkeys(token['data']) & viewkeys(replacements)
-    else:
-        needs_adjustment = frozenset(token['data']) & frozenset(replacements)
+    needs_adjustment = viewkeys(token['data']) & viewkeys(replacements)
     if needs_adjustment:
         token['data'] = OrderedDict((replacements.get(k, k), v)
                                     for k, v in token['data'].items())


### PR DESCRIPTION
Python 2.6 support was recently dropped in https://github.com/html5lib/html5lib-python/pull/356.

Here's a bit more old code that can be removed.