### PR TITLE
.appveyor.yml: Add Python 3.5 and 3.6 environments

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,7 @@ install:
 build: off
 
 test_script:
-  # Avoid py35-optional, as pypi does not have lxml wheels for py35
-  - python -m tox -e "py35-base,{py27,py33,py34}-{base,optional}"
+  - python -m tox -e "{py27,py33,py34,py35,py36}-{base,optional}"
 
 after_test:
   - python debug-info.py


### PR DESCRIPTION
The Python 3.5 and 3.6 builds pass without problems.