### PR TITLE
Pin pytest to a version that doesn't require six

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 flake8<3.0
-pytest
+pytest==3.2.5
 pytest-expect>=1.1,<2.0
 mock


### PR DESCRIPTION
pytest 3.3.0 added `six>=1.10.0` as a requirement which messes us up. Either we should drop support for six 1.9 or we can land this which pins pytest to a slightly earlier version as a stopgap.