### PR TITLE
Make ReparseException private

### DIFF
--- a/html5lib/_inputstream.py
+++ b/html5lib/_inputstream.py
@@ -9,7 +9,7 @@ import re
 import webencodings
 
 from .constants import EOF, spaceCharacters, asciiLetters, asciiUppercase
-from .constants import ReparseException
+from .constants import _ReparseException
 from . import _utils
 
 from io import StringIO
@@ -530,7 +530,7 @@ class HTMLBinaryInputStream(HTMLUnicodeInputStream):
             self.rawStream.seek(0)
             self.charEncoding = (newEncoding, "certain")
             self.reset()
-            raise ReparseException("Encoding changed from %s to %s" % (self.charEncoding[0], newEncoding))
+            raise _ReparseException("Encoding changed from %s to %s" % (self.charEncoding[0], newEncoding))
 
     def detectBOM(self):
         """Attempts to detect at BOM at the start of the stream. If

--- a/html5lib/constants.py
+++ b/html5lib/constants.py
@@ -2943,5 +2943,5 @@ class DataLossWarning(UserWarning):
     pass
 
 
-class ReparseException(Exception):
+class _ReparseException(Exception):
     pass

--- a/html5lib/html5parser.py
+++ b/html5lib/html5parser.py
@@ -20,7 +20,7 @@ from .constants import (
     adjustForeignAttributes as adjustForeignAttributesMap,
     adjustMathMLAttributes, adjustSVGAttributes,
     E,
-    ReparseException
+    _ReparseException
 )
 
 
@@ -83,7 +83,7 @@ class HTMLParser(object):
 
         try:
             self.mainLoop()
-        except ReparseException:
+        except _ReparseException:
             self.reset()
             self.mainLoop()
 


### PR DESCRIPTION
ReparseException is used internally and not intended for external use.

Fixes #371