### PR TITLE
Remove Appveyor Python 3.3 builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,8 +6,6 @@ environment:
   matrix:
     - TOXENV: py27-base
     - TOXENV: py27-optional
-    - TOXENV: py33-base
-    - TOXENV: py33-optional
     - TOXENV: py34-base
     - TOXENV: py34-optional
     - TOXENV: py35-base


### PR DESCRIPTION
It looks like this was missed in #358. It is causing build failures in #395 and #396.