### PR TITLE
Remove unnecessary use of six.binary_type

### DIFF
--- a/html5lib/_inputstream.py
+++ b/html5lib/_inputstream.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from six import text_type, binary_type
+from six import text_type
 from six.moves import http_client, urllib
 
 import codecs
@@ -908,7 +908,7 @@ class ContentAttrParser(object):
 def lookupEncoding(encoding):
     """Return the python codec name corresponding to an encoding or None if the
     string doesn't correspond to a valid encoding."""
-    if isinstance(encoding, binary_type):
+    if isinstance(encoding, bytes):
         try:
             encoding = encoding.decode("ascii")
         except UnicodeDecodeError:


### PR DESCRIPTION
The `bytes` type is available on all support Pythons. On Python 2 it is an alias of `str` (same as six). Reduce unnecessary compatibility shims and by using modern Python idioms. Makes the code more forward compatible with Python 3.