### PR TITLE
Fix collections imports for Python 3.8

### DIFF
--- a/html5lib/_tokenizer.py
+++ b/html5lib/_tokenizer.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, division, unicode_literals
 
 from six import unichr as chr
 
-from collections import deque
-
 from .constants import spaceCharacters
 from .constants import entities
 from .constants import asciiLetters, asciiUpper2Lower
@@ -14,6 +12,11 @@ from .constants import replacementCharacters
 from ._inputstream import HTMLInputStream
 
 from ._trie import Trie
+
+try:
+    from collections.abc import deque
+except ImportError:
+    from collections import deque
 
 entitiesTrie = Trie(entities)
 

--- a/html5lib/filters/alphabeticalattributes.py
+++ b/html5lib/filters/alphabeticalattributes.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, division, unicode_literals
 
 from . import base
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 
 def _attr_key(attr):

--- a/html5lib/html5parser.py
+++ b/html5lib/html5parser.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, unicode_literals
 from six import with_metaclass, viewkeys
 
 import types
-from collections import OrderedDict
 
 from . import _inputstream
 from . import _tokenizer
@@ -22,6 +21,11 @@ from .constants import (
     E,
     _ReparseException
 )
+
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 
 def parse(doc, treebuilder="etree", namespaceHTMLElements=True, **kwargs):

--- a/html5lib/tests/test_alphabeticalattributes.py
+++ b/html5lib/tests/test_alphabeticalattributes.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from collections import OrderedDict
-
 import pytest
 
 import html5lib
 from html5lib.filters.alphabeticalattributes import Filter
 from html5lib.serializer import HTMLSerializer
+
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 
 @pytest.mark.parametrize('msg, attrs, expected_attrs', [

--- a/html5lib/treewalkers/etree.py
+++ b/html5lib/treewalkers/etree.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from collections import OrderedDict
 import re
 
 from six import string_types
 
 from . import base
 from .._utils import moduleFactoryFactory
+
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 tag_regexp = re.compile("{([^}]*)}(.*)")
 


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated

Fixes #405 