### PR TITLE
Add testing and document support for Python 3.7 & PyPy3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,10 @@ environment:
     - TOXENV: py35-optional
     - TOXENV: py36-base
     - TOXENV: py36-optional
+    - TOXENV: py37-base
+    - TOXENV: py37-optional
+    - TOXENV: py38-base
+    - TOXENV: py38-optional
 
 install:
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "pypy3"
   - "pypy"
+  - "3.8"
   - "3.7"
   - "3.6"
   - "3.5"

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,10 @@ classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: Implementation :: CPython',
+    'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Topic :: Text Processing :: Markup :: HTML'
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36,pypy}-{base,six19,optional}
+envlist = py{27,35,36,37,38,py,py3}-{base,six19,optional}
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.7 was released on June 27, 2018.

https://docs.python.org/3/whatsnew/3.7.html

Use 'dist: xenial' in Travis to allow using Python version 3.7. Travis
officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release