### PR TITLE
Allow data: to not be part of sanitizer’s allowed protocols

### DIFF
--- a/html5lib/filters/sanitizer.py
+++ b/html5lib/filters/sanitizer.py
@@ -825,7 +825,7 @@ class Filter(base.Filter):
                 if uri and uri.scheme:
                     if uri.scheme not in self.allowed_protocols:
                         del attrs[attr]
-                    if uri.scheme == 'data':
+                    elif uri.scheme == 'data':
                         m = data_content_type.match(uri.path)
                         if not m:
                             del attrs[attr]


### PR DESCRIPTION
When `data:` wasn’t permitted, it could attempt to `del attrs[attr]` twice.