### PR TITLE
Remove unnecessary flake8 exclude

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,3 @@ commands =
 [testenv:doc]
 changedir = doc
 commands = sphinx-build -b html . _build
-
-[flake8]
-exclude = ./.tox


### PR DESCRIPTION
Modern flake8 has a good default for exclude that includes the tox
directory.

https://gitlab.com/pycqa/flake8/blob/2b333fad1abe0bdb2e04132eabb0822e6ce63888/src/flake8/defaults.py#L4-14