### PR TITLE
Improve the 'Coercing non-XML name' warning.

### DIFF
--- a/html5lib/_ihatexml.py
+++ b/html5lib/_ihatexml.py
@@ -254,7 +254,7 @@ class InfosetFilter(object):
         nameRest = name[1:]
         m = nonXmlNameFirstBMPRegexp.match(nameFirst)
         if m:
-            warnings.warn("Coercing non-XML name", DataLossWarning)
+            warnings.warn("Coercing non-XML name: %s" % name, DataLossWarning)
             nameFirstOutput = self.getReplacementCharacter(nameFirst)
         else:
             nameFirstOutput = nameFirst
@@ -262,7 +262,7 @@ class InfosetFilter(object):
         nameRestOutput = nameRest
         replaceChars = set(nonXmlNameBMPRegexp.findall(nameRest))
         for char in replaceChars:
-            warnings.warn("Coercing non-XML name", DataLossWarning)
+            warnings.warn("Coercing non-XML name: %s" % name, DataLossWarning)
             replacement = self.getReplacementCharacter(char)
             nameRestOutput = nameRestOutput.replace(char, replacement)
         return nameFirstOutput + nameRestOutput


### PR DESCRIPTION
This can be helpful in finding the code triggering the warning.