### PR TITLE
Fix Pytest4.x compatibility error

### DIFF
--- a/html5lib/tests/test_stream.py
+++ b/html5lib/tests/test_stream.py
@@ -308,9 +308,11 @@ def test_invalid_codepoints(inp, num):
                           ("'\\uD800\\uD800\\uD800'", 3),
                           ("'a\\uD800a\\uD800a\\uD800a'", 3),
                           ("'\\uDFFF\\uDBFF'", 2),
-                          pytest.mark.skipif(sys.maxunicode == 0xFFFF,
-                                             ("'\\uDBFF\\uDFFF'", 2),
-                                             reason="narrow Python")])
+                          pytest.param(
+                              "'\\uDBFF\\uDFFF'", 2,
+                              marks=pytest.mark.skipif(
+                                  sys.maxunicode == 0xFFFF,
+                                  reason="narrow Python"))])
 def test_invalid_codepoints_surrogates(inp, num):
     inp = eval(inp)  # pylint:disable=eval-used
     fp = StringIO(inp)


### PR DESCRIPTION
According to pytest docs:
```
marks in pytest.mark.parametrize
Removed in version 4.0.

Applying marks to values of a pytest.mark.parametrize call is now deprecated.
...

This was considered hard to read and understand, and also its implementation
presented problems to the code preventing further internal improvements in the
marks architecture.

To update the code, use pytest.param
```