### PR TITLE
Upgrade datrie to 0.8+, but not yet for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "pypy3"
   - "pypy"
+  - "3.9-dev"
   - "3.8"
   - "3.7"
   - "3.6"

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -14,6 +14,4 @@ lxml ; platform_python_implementation == 'CPython'
 
 # DATrie can be used in place of our Python trie implementation for
 # slightly better parsing performance.
-# https://github.com/pytries/datrie/issues/52 although closed is not
-# yet released to https://pypi.org/project/datrie
-datrie ; platform_python_implementation == 'CPython' and python_version < '3.7'
+datrie>=0.8 ; platform_python_implementation == 'CPython'

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -14,4 +14,5 @@ lxml ; platform_python_implementation == 'CPython'
 
 # DATrie can be used in place of our Python trie implementation for
 # slightly better parsing performance.
-datrie>=0.8 ; platform_python_implementation == 'CPython'
+# https://github.com/pytries/datrie/issues/73 Latest datrie 0.8 doesn't support Py3.8
+datrie>=0.8 ; platform_python_implementation == 'CPython' and python_version < '3.8'

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -14,5 +14,4 @@ lxml ; platform_python_implementation == 'CPython'
 
 # DATrie can be used in place of our Python trie implementation for
 # slightly better parsing performance.
-# https://github.com/pytries/datrie/issues/73 Latest datrie 0.8 doesn't support Py3.8
-datrie>=0.8 ; platform_python_implementation == 'CPython' and python_version < '3.8'
+datrie>=0.8.2 ; platform_python_implementation == 'CPython'


### PR DESCRIPTION
Re: #442.

The latest datrie 0.8 supports Python 3.7: https://github.com/pytries/datrie/issues/52

But it doesn't yet support Python 3.8: https://github.com/pytries/datrie/issues/73