### PR TITLE
Document Python support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,12 +91,14 @@ More documentation is available at https://html5lib.readthedocs.io/.
 Installation
 ------------
 
-html5lib works on CPython 2.7+, CPython 3.4+ and PyPy.  To install it,
-use:
+html5lib works on CPython 2.7+, CPython 3.5+ and PyPy. To install:
 
 .. code-block:: bash
 
     $ pip install html5lib
+
+The goal is to support a (non-strict) superset of the versions that [pip
+supports](https://pip.pypa.io/en/stable/installing/#python-and-os-compatibility).
 
 
 Optional Dependencies


### PR DESCRIPTION
Suggestion to fix https://github.com/html5lib/html5lib-python/issues/439.

Also update list of supported versions, EOL 3.4 was dropped in https://github.com/html5lib/html5lib-python/pull/421 (and pypa/pip@2c1010e dropped support for 3.4 in pip, shipped in 19.2).