### PR TITLE
Fix #488: append document-child comments in document order in lxml

### DIFF
--- a/.pytest.expect
+++ b/.pytest.expect
@@ -1297,8 +1297,6 @@ u'html5lib/tests/testdata/tree-construction/tests8.dat::5::cElementTree::parser:
 u'html5lib/tests/testdata/tree-construction/tests8.dat::5::cElementTree::parser::void-namespace': FAIL
 u'html5lib/tests/testdata/tree-construction/tests8.dat::5::lxml::parser::namespaced': FAIL
 u'html5lib/tests/testdata/tree-construction/tests8.dat::5::lxml::parser::void-namespace': FAIL
-u'html5lib/tests/testdata/tree-construction/webkit01.dat::22::lxml::parser::namespaced': FAIL
-u'html5lib/tests/testdata/tree-construction/webkit01.dat::22::lxml::parser::void-namespace': FAIL
 u'html5lib/tests/testdata/tree-construction/webkit02.dat::14::DOM::parser::namespaced': FAIL
 u'html5lib/tests/testdata/tree-construction/webkit02.dat::14::DOM::parser::void-namespace': FAIL
 u'html5lib/tests/testdata/tree-construction/webkit02.dat::14::ElementTree::parser::namespaced': FAIL

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,7 @@ cache: pip
 env:
   global:
     - PYTEST_COMMAND="coverage run -m pytest"
-  matrix:
-    - TOXENV=optional
-    - TOXENV=base
-    - TOXENV=six19-optional
+    - TOXENV=base,optional,six19-optional
 
 install:
   - pip install tox codecov

--- a/html5lib/treebuilders/etree_lxml.py
+++ b/html5lib/treebuilders/etree_lxml.py
@@ -44,7 +44,11 @@ class Document(object):
         self._childNodes = []
 
     def appendChild(self, element):
-        self._elementTree.getroot().addnext(element._element)
+        last = self._elementTree.getroot()
+        for last in self._elementTree.getroot().itersiblings():
+            pass
+
+        last.addnext(element._element)
 
     def _getChildNodes(self):
         return self._childNodes


### PR DESCRIPTION
Fixes #488. Note that this still needs tests.