### PR TITLE
Don't use cElementTree on Python 3

### DIFF
--- a/html5lib/_utils.py
+++ b/html5lib/_utils.py
@@ -7,12 +7,15 @@ try:
 except ImportError:
     from collections import Mapping
 
-from six import text_type
+from six import text_type, PY3
 
-try:
-    import xml.etree.cElementTree as default_etree
-except ImportError:
+if PY3:
     import xml.etree.ElementTree as default_etree
+else:
+    try:
+        import xml.etree.cElementTree as default_etree
+    except ImportError:
+        import xml.etree.ElementTree as default_etree
 
 
 __all__ = ["default_etree", "MethodDispatcher", "isSurrogatePair",


### PR DESCRIPTION
This just directly imports the first commit from https://github.com/pypa/pip/pull/8278. Fixes #494. This doesn't fill me with joy, but I guess sometimes we do the perhaps silly thing for pip.

(@tiran this is just your commit, let me know if you have any objection to it landing here)