### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,15 @@ script:
 
 after_script:
   - python debug-info.py
+
+arch:
+  - amd64
+  - ppc64le    
+
+jobs:
+  exclude:
+    - arch: ppc64le
+      python: pypy
+    - arch: ppc64le
+      python: pypy3
+


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. ALso I had excluded the jobs for pypy and pypy3 on the ppc64le architecture as pypy is still not supported on the platform. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/html5lib-python/builds/186713011

Please have a look.

Regards,
Kishor Kunal Raj