### PR TITLE
Import collection ABCs from collections.abc

### DIFF
--- a/html5lib/_tokenizer.py
+++ b/html5lib/_tokenizer.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import, division, unicode_literals
 
 from six import unichr as chr
 
-from collections import deque, OrderedDict
+from collections import deque
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 from sys import version_info
 
 from .constants import spaceCharacters

--- a/html5lib/filters/alphabeticalattributes.py
+++ b/html5lib/filters/alphabeticalattributes.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, division, unicode_literals
 
 from . import base
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 
 def _attr_key(attr):

--- a/html5lib/tests/test_alphabeticalattributes.py
+++ b/html5lib/tests/test_alphabeticalattributes.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 import pytest
 

--- a/html5lib/treewalkers/etree.py
+++ b/html5lib/treewalkers/etree.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 import re
 
 from six import string_types


### PR DESCRIPTION
`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 
3.3, and in 3.9 it will stop working`