### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+  - amd64
+  - ppc64le
 python:
   - "pypy3"
   - "pypy"
@@ -8,7 +11,15 @@ python:
   - "3.5"
   - "2.7"
   - "3.9-dev"
-
+# ppc64le specific code
+jobs:  
+  exclude:
+    - arch: ppc64le
+      python:
+        - "pypy3"
+    - arch: ppc64le
+      python:
+        - "pypy"   
 cache: pip
 
 env:


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/html5lib-python