### PR TITLE
Add support for Python 3.9 and 3.10 and 3.11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-# To activate, change the Appveyor settings to use `.appveyor.yml`.
+image: Visual Studio 2019
 environment:
   global:
     PATH: "C:\\Python27\\Scripts\\;%PATH%"
@@ -13,6 +13,10 @@ environment:
     - TOXENV: py37-optional
     - TOXENV: py38-base
     - TOXENV: py38-optional
+    - TOXENV: py39-base
+    - TOXENV: py39-optional
+    - TOXENV: py310-base
+    - TOXENV: py310-optional
 
 install:
   - git submodule update --init --recursive

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -8,12 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy-2.7", "pypy-3.8"]
+        python: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-2.7", "pypy-3.8"]
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: pip

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -6,15 +6,18 @@ jobs:
     if: github.event.push || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, pypy-2.7, pypy3]
+        python: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy-2.7", "pypy-3.8"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
+          cachr-dependency-path: "requirements*"
       - run: pip install tox
       - run: tox -e py
       - if: ${{ always() }}

--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: pip
-          cachr-dependency-path: "requirements*"
+          cache-dependency-path: "requirements*.txt"
       - run: pip install tox
       - run: tox -e py
       - if: ${{ always() }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ language: python
 python:
   - "pypy3"
   - "pypy"
+  - "3.10"
+  - "3.9"
   - "3.8"
   - "3.7"
   - "3.6"
   - "3.5"
   - "2.7"
-  - "3.9-dev"
 
 cache: pip
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,7 +95,7 @@ Released on July 14, 2016
   tested, doesn't entirely work, and as far as I can tell is
   completely unused by anyone.**
 
-* Move testsuite to ``py.test``.
+* Move testsuite to ``pytest``.
 
 * **Fix #124: move to webencodings for decoding the input byte stream;
   this makes html5lib compliant with the Encoding Standard, and

--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Tests
 -----
 
 Unit tests require the ``pytest`` and ``mock`` libraries and can be
-run using the ``py.test`` command in the root directory.
+run using the ``pytest`` command in the root directory.
 
 Test data are contained in a separate `html5lib-tests
 <https://github.com/html5lib/html5lib-tests>`_ repository and included

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38,py,py3}-{base,six19,optional}
+envlist = py{27,35,36,37,38,39,310,311,py,py3}-{base,six19,optional}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv =
   COVERAGE_RUN_OPTIONS
 commands =
   six19: pip install six==1.9
-  {env:PYTEST_COMMAND:{envbindir}/py.test} {posargs}
+  {env:PYTEST_COMMAND:{envbindir}/pytest} {posargs}
   flake8 {toxinidir}
 
 [testenv:doc]


### PR DESCRIPTION
Closes https://github.com/html5lib/html5lib-python/issues/537.

Python 3.9 was released on 2020-10-05.

Python 3.10 was released on 2021-10-04.

Python 3.11 was released on 2022-10-24.

Let's test them and declare support.