### PR TITLE
README: Replace broken mailing list link with archive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,8 +144,9 @@ which can be found on PyPI.
 Questions?
 ----------
 
-Ask on IRC in `#whatwg on irc.freenode.net
-<http://wiki.whatwg.org/wiki/IRC>`_.
+Check out `the docs https://html5lib.readthedocs.io/en/latest/`_. Still
+need help? Go to our `Github Discussions
+https://github.com/html5lib/html5lib-python/discussions`_.
 
-Or browse the archives of the `html5lib-discuss mailing list 
+You can also browse the archives of the `html5lib-discuss mailing list 
 https://www.mail-archive.com/html5lib-discuss@googlegroups.com/`_.

--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ Questions?
 ----------
 
 Check out `the docs https://html5lib.readthedocs.io/en/latest/`_. Still
-need help? Go to our `Github Discussions
+need help? Go to our `GitHub Discussions
 https://github.com/html5lib/html5lib-python/discussions`_.
 
 You can also browse the archives of the `html5lib-discuss mailing list 

--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,8 @@ which can be found on PyPI.
 Questions?
 ----------
 
-There's a mailing list available for support on Google Groups,
-`html5lib-discuss <http://groups.google.com/group/html5lib-discuss>`_,
-though you may get a quicker response asking on IRC in `#whatwg on
-irc.freenode.net <http://wiki.whatwg.org/wiki/IRC>`_.
+Ask on IRC in `#whatwg on irc.freenode.net
+<http://wiki.whatwg.org/wiki/IRC>`_.
+
+Or browse the archives of the `html5lib-discuss mailing list 
+https://www.mail-archive.com/html5lib-discuss@googlegroups.com/`_.


### PR DESCRIPTION
Fixes https://github.com/html5lib/html5lib-python/issues/535.

Alternatively, we could just remove mention of the mailing list. And is the IRC channel still active?