### PR TITLE
Fix pytest warnings

### DIFF
--- a/html5lib/tests/test_sanitizer.py
+++ b/html5lib/tests/test_sanitizer.py
@@ -1,9 +1,14 @@
 from __future__ import absolute_import, division, unicode_literals
 
+import warnings
+
 import pytest
 
 from html5lib import constants, parseFragment, serialize
-from html5lib.filters import sanitizer
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from html5lib.filters import sanitizer
 
 
 def sanitize_html(stream):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 # Output fails, errors, xpass, and warnings; ignore doctest; make warnings errors
-addopts = -rfEXw -p no:doctest --strict
+addopts = -rfEXw -p no:doctest --strict-markers
 
 # Make xpass results be considered fail
 xfail_strict = true


### PR DESCRIPTION
Fixes https://github.com/html5lib/html5lib-python/issues/529.

Fixes `PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.`

Also don't show own `DeprecationWarning` when testing own code.

# Before

```console
$ tox -e py38
GLOB sdist-make: /private/tmp/html5lib-python/setup.py
py38 inst-nodeps: /private/tmp/html5lib-python/.tox/.tmp/package/1/html5lib-1.2.dev0.zip
py38 installed: attrs==21.4.0,coverage==5.5,distlib==0.3.4,filelock==3.6.0,flake8==3.8.4,html5lib @ file:///private/tmp/html5lib-python/.tox/.tmp/package/1/html5lib-1.2.dev0.zip,iniconfig==1.1.1,mccabe==0.6.1,mock==4.0.3,packaging==21.3,platformdirs==2.5.1,pluggy==1.0.0,py==1.11.0,pycodestyle==2.6.0,pyflakes==2.2.0,pyparsing==3.0.7,pytest==6.2.5,pytest-expect==1.1.0,six==1.16.0,toml==0.10.2,tox==3.24.5,u-msgpack-python==2.7.1,virtualenv==20.14.0,webencodings==0.5.1
py38 run-test-pre: PYTHONHASHSEED='4056569232'
py38 run-test: commands[0] | /private/tmp/html5lib-python/.tox/py38/bin/py.test
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.8.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
cachedir: .tox/py38/.pytest_cache
rootdir: /private/tmp/html5lib-python, configfile: pytest.ini
plugins: expect-1.1.0
collected 991 items

html5lib/tests/test_alphabeticalattributes.py .....                                                                                         [  0%]
html5lib/tests/test_encoding.py ............................ss                                                                              [  3%]
html5lib/tests/test_meta.py .                                                                                                               [  3%]
html5lib/tests/test_optionaltags_filter.py .                                                                                                [  3%]
html5lib/tests/test_parser2.py ..........                                                                                                   [  4%]
html5lib/tests/test_sanitizer.py .......................................................................................................... [ 15%]
........................................................................................................................................... [ 29%]
........................................................................................................................................... [ 43%]
.................                                                                                                                           [ 45%]
html5lib/tests/test_serializer.py ........................................................................................sss.............. [ 55%]
........................................................................................................................................... [ 69%]
..................................................................................                                                          [ 78%]
html5lib/tests/test_stream.py ..................................................................................................            [ 87%]
html5lib/tests/test_tokenizer2.py ...                                                                                                       [ 88%]
html5lib/tests/test_treeadapters.py .                                                                                                       [ 88%]
html5lib/tests/test_treewalkers.py .....ssssss....sssssssssssssssss                                                                         [ 91%]
html5lib/tests/test_whitespace_filter.py ...........                                                                                        [ 92%]
html5lib/tests/sanitizer-testdata/tests1.dat ........................................................................                       [100%]

================================================================ warnings summary =================================================================
.tox/py38/lib/python3.8/site-packages/_pytest/config/__init__.py:1183
  /private/tmp/html5lib-python/.tox/py38/lib/python3.8/site-packages/_pytest/config/__init__.py:1183: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(

html5lib/filters/sanitizer.py:29
  /private/tmp/html5lib-python/html5lib/filters/sanitizer.py:29: DeprecationWarning: html5lib's sanitizer is deprecated; see https://github.com/html5lib/html5lib-python/issues/443 and please let us know if Bleach is unsuitable for your needs
    warnings.warn(_deprecation_msg, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================== 963 passed, 28 skipped, 2 warnings in 0.97s ===================================================
py38 run-test: commands[1] | flake8 /private/tmp/html5lib-python
_____________________________________________________________________ summary _____________________________________________________________________
  py38: commands succeeded
  congratulations :)
```

# After

```console
$ tox -e py38
GLOB sdist-make: /private/tmp/html5lib-python/setup.py
py38 inst-nodeps: /private/tmp/html5lib-python/.tox/.tmp/package/1/html5lib-1.2.dev0.zip
py38 installed: attrs==21.4.0,coverage==5.5,distlib==0.3.4,filelock==3.6.0,flake8==3.8.4,html5lib @ file:///private/tmp/html5lib-python/.tox/.tmp/package/1/html5lib-1.2.dev0.zip,iniconfig==1.1.1,mccabe==0.6.1,mock==4.0.3,packaging==21.3,platformdirs==2.5.1,pluggy==1.0.0,py==1.11.0,pycodestyle==2.6.0,pyflakes==2.2.0,pyparsing==3.0.7,pytest==6.2.5,pytest-expect==1.1.0,six==1.16.0,toml==0.10.2,tox==3.24.5,u-msgpack-python==2.7.1,virtualenv==20.14.0,webencodings==0.5.1
py38 run-test-pre: PYTHONHASHSEED='3043936860'
py38 run-test: commands[0] | /private/tmp/html5lib-python/.tox/py38/bin/py.test
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.8.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
cachedir: .tox/py38/.pytest_cache
rootdir: /private/tmp/html5lib-python, configfile: pytest.ini
plugins: expect-1.1.0
collected 991 items

html5lib/tests/test_alphabeticalattributes.py .....                                                                                         [  0%]
html5lib/tests/test_encoding.py ............................ss                                                                              [  3%]
html5lib/tests/test_meta.py .                                                                                                               [  3%]
html5lib/tests/test_optionaltags_filter.py .                                                                                                [  3%]
html5lib/tests/test_parser2.py ..........                                                                                                   [  4%]
html5lib/tests/test_sanitizer.py .......................................................................................................... [ 15%]
........................................................................................................................................... [ 29%]
........................................................................................................................................... [ 43%]
.................                                                                                                                           [ 45%]
html5lib/tests/test_serializer.py ........................................................................................sss.............. [ 55%]
........................................................................................................................................... [ 69%]
..................................................................................                                                          [ 78%]
html5lib/tests/test_stream.py ..................................................................................................            [ 87%]
html5lib/tests/test_tokenizer2.py ...                                                                                                       [ 88%]
html5lib/tests/test_treeadapters.py .                                                                                                       [ 88%]
html5lib/tests/test_treewalkers.py .....ssssss....sssssssssssssssss                                                                         [ 91%]
html5lib/tests/test_whitespace_filter.py ...........                                                                                        [ 92%]
html5lib/tests/sanitizer-testdata/tests1.dat ........................................................................                       [100%]

========================================================= 963 passed, 28 skipped in 0.92s =========================================================
py38 run-test: commands[1] | flake8 /private/tmp/html5lib-python
_____________________________________________________________________ summary _____________________________________________________________________
  py38: commands succeeded
  congratulations :)
```
