### PR TITLE
Bump Flake8 to fix CI for Python 3.7

### DIFF
--- a/html5lib/_inputstream.py
+++ b/html5lib/_inputstream.py
@@ -324,7 +324,7 @@ class HTMLUnicodeInputStream(object):
         except KeyError:
             if __debug__:
                 for c in characters:
-                    assert(ord(c) < 128)
+                    assert ord(c) < 128
             regex = "".join(["\\x%02x" % ord(c) for c in characters])
             if not opposite:
                 regex = "^%s" % regex

--- a/html5lib/serializer.py
+++ b/html5lib/serializer.py
@@ -222,14 +222,14 @@ class HTMLSerializer(object):
         self.strict = False
 
     def encode(self, string):
-        assert(isinstance(string, text_type))
+        assert isinstance(string, text_type)
         if self.encoding:
             return string.encode(self.encoding, "htmlentityreplace")
         else:
             return string
 
     def encodeStrict(self, string):
-        assert(isinstance(string, text_type))
+        assert isinstance(string, text_type)
         if self.encoding:
             return string.encode(self.encoding, "strict")
         else:

--- a/html5lib/tests/test_serializer.py
+++ b/html5lib/tests/test_serializer.py
@@ -74,7 +74,7 @@ class JsonWalker(TreeWalker):
         attrs = {}
         for attrib in attribs:
             name = (attrib["namespace"], attrib["name"])
-            assert(name not in attrs)
+            assert name not in attrs
             attrs[name] = attrib["value"]
         return attrs
 

--- a/html5lib/treebuilders/etree.py
+++ b/html5lib/treebuilders/etree.py
@@ -108,7 +108,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
             node.parent = None
 
         def insertText(self, data, insertBefore=None):
-            if not(len(self._element)):
+            if not len(self._element):
                 if not self._element.text:
                     self._element.text = ""
                 self._element.text += data
@@ -201,7 +201,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
         rv = []
 
         def serializeElement(element, indent=0):
-            if not(hasattr(element, "tag")):
+            if not hasattr(element, "tag"):
                 element = element.getroot()
             if element.tag == "<!DOCTYPE>":
                 if element.get("publicId") or element.get("systemId"):

--- a/html5lib/treewalkers/etree.py
+++ b/html5lib/treewalkers/etree.py
@@ -37,7 +37,7 @@ def getETreeBuilder(ElementTreeImplementation):
                 else:
                     node = elt
 
-            if not(hasattr(node, "tag")):
+            if not hasattr(node, "tag"):
                 node = node.getroot()
 
             if node.tag in ("DOCUMENT_ROOT", "DOCUMENT_FRAGMENT"):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 tox>=3.15.1,<4
-flake8>=3.8.1,<3.9
+flake8>=3.8.1,<6
 pytest>=4.6.10,<5 ; python_version < '3'
 pytest>=5.4.2,<7 ; python_version >= '3'
 coverage>=5.1,<6


### PR DESCRIPTION
The Python 3.7 CI job [has started failing](https://github.com/html5lib/html5lib-python/actions/runs/3206548648/jobs/5240435219):

```
    self._load_entrypoint_plugins()
  File "/home/runner/work/html5lib-python/html5lib-python/.tox/py/lib/python3.7/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
AttributeError: 'EntryPoints' object has no attribute 'get'
ERROR: InvocationError for command /home/runner/work/html5lib-python/html5lib-python/.tox/py/bin/flake8 . (exited with code 1)
```

This is because importlib_metadata 5.0 removes some deprecations, and it's a dependency of Flake8. But new Flake8 works, so let's update:

* https://github.com/python/importlib_metadata/issues/406
* https://github.com/PyCQA/flake8/issues/1701

Also fix the new Flake8 findings:

```
./html5lib/_inputstream.py:327:27: E275 missing whitespace after keyword
./html5lib/serializer.py:225:15: E275 missing whitespace after keyword
./html5lib/serializer.py:232:15: E275 missing whitespace after keyword
./html5lib/treewalkers/etree.py:40:19: E275 missing whitespace after keyword
./html5lib/treebuilders/etree.py:111:19: E275 missing whitespace after keyword
./html5lib/treebuilders/etree.py:204:19: E275 missing whitespace after keyword
./html5lib/tests/test_serializer.py:77:19: E275 missing whitespace after keyword
```
