### PR TITLE
Sort void elements alphabetically, document ones that don't match current standard

### DIFF
--- a/html5lib/constants.py
+++ b/html5lib/constants.py
@@ -557,23 +557,35 @@ headingElements = (
 )
 
 voidElements = frozenset([
+    "area",
     "base",
-    "command",
-    "event-source",
+    "br",
+    "col",
+    "command",  # removed ^1
+    "embed",
+    "event-source",  # renamed and later removed ^2
+    "hr",
+    "img",
+    "input",
     "link",
     "meta",
-    "hr",
-    "br",
-    "img",
-    "embed",
-    "param",
-    "area",
-    "col",
-    "input",
+    "param",  # deprecated ^3
     "source",
     "track",
     "wbr",
 ])
+
+# Removals and deprecations in the HTML 5 spec:
+# ^1: command
+#     http://lists.whatwg.org/pipermail/whatwg-whatwg.org/2012-December/038472.html 
+#     https://github.com/whatwg/html/commit/9e2e25f4ae90969a7c64e0763c98548a35b50af8
+# ^2: event-source
+#     renamed to eventsource in 7/2008:
+#     https://github.com/whatwg/html/commit/d157945d0285b4463a04b57318da0c4b300a99e7
+#     removed entirely in 2/2009:
+#     https://github.com/whatwg/html/commit/43cbdbfbb7eb74b0d65e0f4caab2020c0b2a16ff
+# ^3: param
+#     https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param
 
 cdataElements = frozenset(['title', 'textarea'])
 

--- a/html5lib/constants.py
+++ b/html5lib/constants.py
@@ -577,7 +577,7 @@ voidElements = frozenset([
 
 # Removals and deprecations in the HTML 5 spec:
 # ^1: command
-#     http://lists.whatwg.org/pipermail/whatwg-whatwg.org/2012-December/038472.html 
+#     http://lists.whatwg.org/pipermail/whatwg-whatwg.org/2012-December/038472.html
 #     https://github.com/whatwg/html/commit/9e2e25f4ae90969a7c64e0763c98548a35b50af8
 # ^2: event-source
 #     renamed to eventsource in 7/2008:


### PR DESCRIPTION
While I believe we could just remove `command` and `event-source` (as I commented on the issue), it's safer just to leave them be for now and revisit this for "2.0".

To not lose track of the fact that those two elements are out of place, this PR just documents their removals. More importantly, it sorts the elements so it's easier to compare them with sources of truth:
- https://html.spec.whatwg.org/#void-elements; and the more wordy
- https://developer.mozilla.org/en-US/docs/Glossary/Void_element

Fixes #203