### PR TITLE
adapt testsuite to changes in pytest 7.4

### DIFF
--- a/html5lib/tests/tokenizer.py
+++ b/html5lib/tests/tokenizer.py
@@ -246,7 +246,7 @@ class TokenizerTest(pytest.Item):
     def repr_failure(self, excinfo):
         traceback = excinfo.traceback
         ntraceback = traceback.cut(path=__file__)
-        excinfo.traceback = ntraceback.filter()
+        excinfo.traceback = ntraceback.filter(excinfo)
 
         return excinfo.getrepr(funcargs=True,
                                showlocals=False,

--- a/html5lib/tests/tree_construction.py
+++ b/html5lib/tests/tree_construction.py
@@ -135,7 +135,7 @@ class ParserTest(pytest.Item):
     def repr_failure(self, excinfo):
         traceback = excinfo.traceback
         ntraceback = traceback.cut(path=__file__)
-        excinfo.traceback = ntraceback.filter()
+        excinfo.traceback = ntraceback.filter(excinfo)
 
         return excinfo.getrepr(funcargs=True,
                                showlocals=False,


### PR DESCRIPTION
Pytest 7.4 made `_excinfo_or_fn` argument in `traceback.filter()` mandatory: https://github.com/pytest-dev/pytest/commit/cc23ec91d042ee15145b890aea04e96f6e831101