### PR TITLE
tests: drop dependency on external mock module for newer python

### DIFF
--- a/html5lib/tests/test_meta.py
+++ b/html5lib/tests/test_meta.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, unicode_literals
 import six
 try:
     from unittest.mock import Mock
-except:
+except ImportError:
     from mock import Mock
 
 from . import support

--- a/html5lib/tests/test_meta.py
+++ b/html5lib/tests/test_meta.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import six
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except:
+    from mock import Mock
 
 from . import support
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,5 +6,4 @@ pytest>=4.6.10,<5 ; python_version < '3'
 pytest>=5.4.2,<7 ; python_version >= '3'
 coverage>=5.1,<6
 pytest-expect>=1.1.0,<2
-mock>=3.0.5,<4 ; python_version < '3.6'
-mock>=4.0.2,<5 ; python_version >= '3.6'
+mock>=3.0.5,<4 ; python_version < '3.3'


### PR DESCRIPTION
Starting python 3.3, this is in the stdlib.

Fixes #541