### PR TITLE
AppVeyor: Test EOL versions of CPython

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,4 @@
+# https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019
 image: Visual Studio 2019
 environment:
   global:
@@ -9,6 +10,12 @@ environment:
     - TOXENV: py35-optional
     - TOXENV: py36-base
     - TOXENV: py36-optional
+    - TOXENV: py37-base
+    - TOXENV: py37-optional
+    - TOXENV: py38-base
+    - TOXENV: py38-optional
+    - TOXENV: py312-base
+    - TOXENV: py312-optional
 
 install:
   - git submodule update --init --recursive
@@ -17,6 +24,7 @@ install:
 build: off
 
 test_script:
+  - py --list
   - tox
 
 after_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,13 +16,15 @@ environment:
 
 install:
   - git submodule update --init --recursive
-  - python -m pip install tox
+  - py --list
+  - py -VV
+  - py -m pip install --upgrade pip
+  - py -m pip install tox
 
 build: off
 
 test_script:
-  - py --list
-  - tox
+  - py -m tox
 
 after_test:
   - python debug-info.py

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,21 +1,18 @@
+# appveyor.yml - https://www.appveyor.com/docs/lang/python
 # https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019
+# https://www.appveyor.com/docs/windows-images-software/#visual-studio-2022
+---
 image: Visual Studio 2019
 environment:
-  global:
-    PATH: "C:\\Python27\\Scripts\\;%PATH%"
   matrix:
-    - TOXENV: py27-base
-    - TOXENV: py27-optional
-    - TOXENV: py35-base
-    - TOXENV: py35-optional
-    - TOXENV: py36-base
-    - TOXENV: py36-optional
-    - TOXENV: py37-base
-    - TOXENV: py37-optional
-    - TOXENV: py38-base
-    - TOXENV: py38-optional
-    - TOXENV: py312-base
-    - TOXENV: py312-optional
+    - PY_PYTHON: 2.7
+      TOXENV: py27-base
+    - PY_PYTHON: 2.7
+      TOXENV: py27-optional
+    - PY_PYTHON: 3.7
+      TOXENV: py37-base
+    - PY_PYTHON: 3.7
+      TOXENV: py37-optional
 
 install:
   - git submodule update --init --recursive


### PR DESCRIPTION
Run `py --list` to see which versions of Python are present.
* https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019

$ `py --list`
```
 -V:3.12 *        Python 3.12 (64-bit)
 -V:3.12-32       Python 3.12 (32-bit)
 -V:3.11          Python 3.11 (64-bit)
 -V:3.11-32       Python 3.11 (32-bit)
 -V:3.10          Python 3.10 (64-bit)
 -V:3.10-32       Python 3.10 (32-bit)
 -V:3.9           Python 3.9 (64-bit)
 -V:3.9-32        Python 3.9 (32-bit)
 -V:3.8           Python 3.8 (64-bit)
 -V:3.8-32        Python 3.8 (32-bit)
 -V:3.7           Python 3.7 (64-bit)
 -V:3.7-32        Python 3.7 (32-bit)
 -V:2.7           Python 2.7
 -V:2.7-32        Python 2.7-32
 -V:2.6           Python 2.6
 -V:2.6-32        Python 2.6-32
 -V:ContinuumAnalytics/Anaconda38-64 Anaconda 4.8.2
 -V:ContinuumAnalytics/Anaconda37-32 Anaconda 4.8.2
 -V:ContinuumAnalytics/Anaconda37-64 Anaconda 4.8.2
 -V:ContinuumAnalytics/Anaconda36-32 Anaconda 4.5.4
 -V:ContinuumAnalytics/Anaconda36-64 Anaconda 4.5.4
 -V:ContinuumAnalytics/Anaconda35-32 Anaconda 4.2.12
 -V:ContinuumAnalytics/Anaconda35-64 Anaconda 4.2.12
 -V:ContinuumAnalytics/Anaconda27-32 Anaconda 4.7.12
 -V:ContinuumAnalytics/Anaconda27-64 Anaconda 4.7.12
```