### PR TITLE
Make parsing of text be non-quadratic.

### DIFF
--- a/html5lib/treewalkers/etree.py
+++ b/html5lib/treewalkers/etree.py
@@ -33,7 +33,7 @@ def getETreeBuilder(ElementTreeImplementation):
             if isinstance(node, tuple):  # It might be the root Element
                 elt, _, _, flag = node
                 if flag in ("text", "tail"):
-                    return base.TEXT, getattr(elt, flag)
+                    return base.TEXT, getattr(elt, flag).getvalue()
                 else:
                     node = elt
 
@@ -44,11 +44,15 @@ def getETreeBuilder(ElementTreeImplementation):
                 return (base.DOCUMENT,)
 
             elif node.tag == "<!DOCTYPE>":
-                return (base.DOCTYPE, node.text,
-                        node.get("publicId"), node.get("systemId"))
+                return (
+                    base.DOCTYPE,
+                    node.text.getvalue(),
+                    node.get("publicId"),
+                    node.get("systemId"),
+                )
 
             elif node.tag == ElementTreeCommentType:
-                return base.COMMENT, node.text
+                return base.COMMENT, node.text.getvalue()
 
             else:
                 assert isinstance(node.tag, string_types), type(node.tag)


### PR DESCRIPTION
In Python, appending strings is not guaranteed to be constant-time, since they are documented to be immutable.  In some corner cases, CPython is able to make these operations constant-time, but reaching into ETree objects is not such a case.

This leads to parse times being quadratic in the size of the text in the input in pathological cases where parsing outputs a large number of adjacent text nodes which must be combined (e.g. HTML-escaped values).  Specifically, we expect doubling the size of the input to result in approximately doubling the time to parse; instead, we observe quadratic behavior:

```
In [1]: import html5lib

In [2]: %timeit -n1 -r5 html5lib.parse("&lt;" * 200000)
2.99 s ± 269 ms per loop (mean ± std. dev. of 5 runs, 1 loop each)

In [3]: %timeit -n1 -r5 html5lib.parse("&lt;" * 400000)
6.7 s ± 242 ms per loop (mean ± std. dev. of 5 runs, 1 loop each)

In [4]: %timeit -n1 -r5 html5lib.parse("&lt;" * 800000)
19.5 s ± 1.48 s per loop (mean ± std. dev. of 5 runs, 1 loop each)
```

Switch from appending to the internal `str`, to appending text to an array of text chunks, as appends can be done in constant time.  Using `bytearray` is a similar solution, but benchmarks slightly worse because the strings must be encoded before being appended.

This improves parsing of text documents noticeably:

```
In [1]: import html5lib

In [2]: %timeit -n1 -r5 html5lib.parse("&lt;" * 200000)
2.3 s ± 373 ms per loop (mean ± std. dev. of 5 runs, 1 loop each)

In [3]: %timeit -n1 -r5 html5lib.parse("&lt;" * 400000)
3.85 s ± 29.7 ms per loop (mean ± std. dev. of 5 runs, 1 loop each)

In [4]: %timeit -n1 -r5 html5lib.parse("&lt;" * 800000)
8.04 s ± 317 ms per loop (mean ± std. dev. of 5 runs, 1 loop each)
```

-----

Old flamegraph:
![](https://github.com/html5lib/html5lib-python/assets/28347/e060490a-fa41-4a04-aca3-27f20a4deb72)

New flamegraph:
![](https://github.com/html5lib/html5lib-python/assets/28347/038f1577-38d6-4c0b-aa0d-425a7590b8b4)