### PR TITLE
Replace pkg resources use

### DIFF
--- a/html5lib/tests/conftest.py
+++ b/html5lib/tests/conftest.py
@@ -2,7 +2,12 @@ from __future__ import print_function
 import os.path
 import sys
 
-import pkg_resources
+from packaging.requirements import Requirement
+from packaging.markers import Marker
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
 import pytest
 
 from .tree_construction import TreeConstructionFile
@@ -63,17 +68,16 @@ def pytest_configure(config):
                             spec, marker = line.strip().split(";", 1)
                         else:
                             spec, marker = line.strip(), None
-                        req = pkg_resources.Requirement.parse(spec)
-                        if marker and not pkg_resources.evaluate_marker(marker):
+                        req = Requirement(spec)
+                        if marker and not Marker(marker).evaluate():
                             msgs.append("%s not available in this environment" % spec)
                         else:
                             try:
-                                installed = pkg_resources.working_set.find(req)
-                            except pkg_resources.VersionConflict:
-                                msgs.append("Outdated version of %s installed, need %s" % (req.name, spec))
-                            else:
-                                if not installed:
-                                    msgs.append("Need %s" % spec)
+                                installed = metadata.version(req.name)
+                                if not req.specifier.contains(installed, prereleases=True):
+                                    msgs.append("Outdated version of %s installed, need %s" % (req.name, spec))
+                            except metadata.PackageNotFoundError:
+                                msgs.append("Need %s" % spec)
 
         # Check cElementTree
         import xml.etree.ElementTree as ElementTree

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,5 @@ coverage>=5.1,<6
 pytest-expect>=1.1.0,<2
 mock>=3.0.5,<4 ; python_version < '3.3'
 setuptools; python_version >= '3.12'
+packaging
+importlib-metadata; python_version < '3.8'

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,12 @@ import sys
 
 from os.path import join, dirname
 from setuptools import setup, find_packages, __version__ as setuptools_version
-from pkg_resources import parse_version
 
-import pkg_resources
+try:
+    import pkg_resources
+    from pkg_resources import parse_version
+except ImportError:
+    pkg_resources = None
 
 try:
     import _markerlib.markers


### PR DESCRIPTION
- [setup.py: except ImportError for missing pkg_resources](https://github.com/html5lib/html5lib-python/commit/3682edfbae66ab0c20f12485015459b98cb81ac9)
  - Missing pkg_resources indicates setuptools 82 or newer which is more recent that than 18.5 so the version check using pkg_resources can safely be skipped.
  - This is an alternative to https://github.com/html5lib/html5lib-python/pull/592 that avoids using setuptools internal namespace `setuptools._vendor.packaging.version`.
  - Fixes https://github.com/html5lib/html5lib-python/issues/593.
- [conftest.py: Replace pkg_resources use with packaging](https://github.com/html5lib/html5lib-python/commit/6a8259230394a9ea4f725ed5f07a2e9107880986)
  - This is python 3+ only and intended to be merged after https://github.com/html5lib/html5lib-python/pull/580
  - I can refactor it so it supports 2.7+ if desired.