### PR TITLE
Fix appveryor pipelines

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,8 @@
 # appveyor.yml - https://www.appveyor.com/docs/lang/python
-# https://www.appveyor.com/docs/windows-images-software/#visual-studio-2022
+# https://www.appveyor.com/docs/windows-images-software/#visual-studio-2017
 ---
-image: Visual Studio 2022
+image: Visual Studio 2017
+
 environment:
   matrix:
     - PY_PYTHON: 2.7

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -10,4 +10,5 @@ chardet>=2.2.1
 
 # lxml is supported with its own treebuilder ("lxml") and otherwise
 # uses the standard ElementTree support
-lxml>=3.4.0 ; platform_python_implementation == 'CPython'
+lxml>=3.4.0, <5.0.0 ; python_version < '3.0' and platform_python_implementation == 'CPython'
+lxml>=3.4.0 ; python_version >= '3.0' and platform_python_implementation == 'CPython'


### PR DESCRIPTION
- Change appveryor's image to Visual Studio 2017 from Visual Studio 2022. Visual Studio 2017 is the most recent Visual Studio image still containing python 3.7.
  - Alternatives:
    - Install python 3.7 on Visual Studio 2022.
    - Switch to a Ubuntu based image.
- Add upper bound < 5.0.0 to lxml for python 2.7 in requirements-optional.txt.
  - Alternatives:
    - Use an upper bound of < 5.1.0 for Linux and 5.1.0 for Windows.
    - Use an upper bound of 5.1.0 and attempt to build lxml from source.
    - Switch to a Ubuntu based image.